### PR TITLE
Fix ARM64 WebRtcInterop build stability

### DIFF
--- a/WebRtcInterop/WebRtcInterop.Shared.vcxitems
+++ b/WebRtcInterop/WebRtcInterop.Shared.vcxitems
@@ -81,7 +81,7 @@ ninja -C "$(WebRtcOutRoot)\$(Configuration)\$(Platform)"
   </ItemDefinitionGroup>
   <ItemDefinitionGroup Condition="'$(Configuration)|$(Platform)'=='Release|ARM64' and '$(WebRtcPrebuilt)' != '1'">
     <CustomBuildStep>
-      <Command>$(WebRtcGnCommandPrefix)target_cpu="arm64" is_debug=false enable_iterator_debugging=false $(WebRtcGnCommonArgs)$(WebRtcGnCommandSuffix)
+      <Command>$(WebRtcGnCommandPrefix)target_cpu="arm64" is_debug=false enable_iterator_debugging=false rtc_enable_win_wgc=false $(WebRtcGnCommonArgs)$(WebRtcGnCommandSuffix)
 </Command>
       <Message>Building Google WebRtc Library</Message>
       <Outputs>$(WebRtcOutRoot)\$(Configuration)\$(Platform)\webrtc.lib</Outputs>
@@ -89,7 +89,7 @@ ninja -C "$(WebRtcOutRoot)\$(Configuration)\$(Platform)"
   </ItemDefinitionGroup>
   <ItemDefinitionGroup Condition="'$(Configuration)|$(Platform)'=='Debug|ARM64' and '$(WebRtcPrebuilt)' != '1'">
     <CustomBuildStep>
-      <Command>$(WebRtcGnCommandPrefix)target_cpu="arm64" is_debug=true enable_iterator_debugging=false $(WebRtcGnCommonArgs)$(WebRtcGnCommandSuffix)
+      <Command>$(WebRtcGnCommandPrefix)target_cpu="arm64" is_debug=true enable_iterator_debugging=false rtc_enable_win_wgc=false $(WebRtcGnCommonArgs)$(WebRtcGnCommandSuffix)
 </Command>
       <Message>Building Google WebRtc Library</Message>
       <Outputs>$(WebRtcOutRoot)\$(Configuration)\$(Platform)\webrtc.lib</Outputs>

--- a/docker/build-webrtc.ps1
+++ b/docker/build-webrtc.ps1
@@ -186,8 +186,10 @@ if ($Mode -in @('full', 'build')) {
       @{ Config = 'Release'; Platform = 'Win32'; Cpu = 'x86'; IsDebug = 'false'; EnableIteratorDebugging = 'false'; ExtraArgs = @() },
       @{ Config = 'Debug';   Platform = 'x64';   Cpu = 'x64'; IsDebug = 'true';  EnableIteratorDebugging = 'true';  ExtraArgs = @() },
       @{ Config = 'Release'; Platform = 'x64';   Cpu = 'x64'; IsDebug = 'false'; EnableIteratorDebugging = 'false'; ExtraArgs = @() },
-      @{ Config = 'Debug';   Platform = 'ARM64'; Cpu = 'arm64'; IsDebug = 'true';  EnableIteratorDebugging = 'false';  ExtraArgs = @() }, #iterator debugging fails for ARM64 builds.
-      @{ Config = 'Release'; Platform = 'ARM64'; Cpu = 'arm64'; IsDebug = 'false'; EnableIteratorDebugging = 'false'; ExtraArgs = @() }
+      # ARM64 disables WGC because it can pull desktop-capture paths that reference
+      # SharedXDisplay::~SharedXDisplay and fail interop linking with packaged webrtc.lib.
+      @{ Config = 'Debug';   Platform = 'ARM64'; Cpu = 'arm64'; IsDebug = 'true';  EnableIteratorDebugging = 'false';  ExtraArgs = @('rtc_enable_win_wgc=false') }, #iterator debugging fails for ARM64 builds.
+      @{ Config = 'Release'; Platform = 'ARM64'; Cpu = 'arm64'; IsDebug = 'false'; EnableIteratorDebugging = 'false'; ExtraArgs = @('rtc_enable_win_wgc=false') }
     )
 
     foreach ($config in $configs) {


### PR DESCRIPTION
## Summary
ARM64-specific WebRtcInterop build stabilization.

## Changes
- Disable `rtc_enable_win_wgc` for ARM64 GN generation paths used in interop builds.
- Keep ARM64 GN configuration aligned between shared items and docker build script.

Closes #26