### PR TITLE
Normalize project build output layout

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,6 +1,9 @@
 *.opensdf
 obj
 bin
+x64
+x86
+ARM64
 .vs
 Debug
 /WebRtcNet.sdf

--- a/Directory.Build.props
+++ b/Directory.Build.props
@@ -10,4 +10,12 @@
 		<AssemblyVersion>0.104.1.0</AssemblyVersion>
 		<FileVersion>0.104.1.0</FileVersion>
 	</PropertyGroup>
+	<PropertyGroup Condition="'$(UsingMicrosoftNETSdk)' == 'true'">
+		<_WebRtcNetManagedPlatform Condition="'$(Platform)' == ''">AnyCPU</_WebRtcNetManagedPlatform>
+		<_WebRtcNetManagedPlatform Condition="'$(Platform)' != ''">$(Platform)</_WebRtcNetManagedPlatform>
+		<OutputPath>bin\$(_WebRtcNetManagedPlatform)\$(Configuration)\</OutputPath>
+		<IntermediateOutputPath>obj\$(_WebRtcNetManagedPlatform)\$(Configuration)\</IntermediateOutputPath>
+		<AppendPlatformToOutputPath>false</AppendPlatformToOutputPath>
+		<AppendTargetFrameworkToOutputPath>true</AppendTargetFrameworkToOutputPath>
+	</PropertyGroup>
 </Project>

--- a/WebRtcInterop.UnitTests/x64/Release/.NETFramework,Version=v4.7.2.AssemblyAttributes.cpp
+++ b/WebRtcInterop.UnitTests/x64/Release/.NETFramework,Version=v4.7.2.AssemblyAttributes.cpp
@@ -1,2 +1,0 @@
-#using <mscorlib.dll>
-[assembly: System::Runtime::Versioning::TargetFrameworkAttribute(L".NETFramework,Version=v4.7.2", FrameworkDisplayName=L".NET Framework 4.7.2")];

--- a/WebRtcNet.Api/WebRtcNet.Api.csproj
+++ b/WebRtcNet.Api/WebRtcNet.Api.csproj
@@ -7,7 +7,7 @@
 		<AssemblyTitle>WebRtcNet.Api</AssemblyTitle>
 		<AssemblyDescription>The public WebRtc interfaces and classes for the WebRtcNet library</AssemblyDescription>
 		<Guid>98433217-c99b-4b08-a19b-3f97a1f1e633</Guid>
-		<DocumentationFile>bin\$(Configuration)\WebRtcNet.Api.XML</DocumentationFile>
+		<DocumentationFile>$(OutputPath)$(TargetFramework)\WebRtcNet.Api.XML</DocumentationFile>
 		<AutoGenerateBindingRedirects>true</AutoGenerateBindingRedirects>
 		<LangVersion>latest</LangVersion>
 		<RootNamespace>WebRtcNet</RootNamespace>

--- a/WebRtcNet/WebRtcNet.csproj
+++ b/WebRtcNet/WebRtcNet.csproj
@@ -14,7 +14,7 @@
   <PropertyGroup>
     <PackageLicenseFile>..\LICENSE</PackageLicenseFile>
     <PackageRequireLicenseAcceptance>True</PackageRequireLicenseAcceptance>
-    <DocumentationFile>bin\$(Configuration)\WebRtcNet.XML</DocumentationFile>
+    <DocumentationFile>$(OutputPath)$(TargetFramework)\WebRtcNet.XML</DocumentationFile>
   </PropertyGroup>
 
   <ItemGroup>


### PR DESCRIPTION
## Summary
Normalize managed/native build output layout and remove tracked generated output noise.

## Changes
- Centralize managed output/intermediate path shaping in `Directory.Build.props`.
- Align managed XML documentation paths with normalized output paths.
- Ignore root-level platform output folders (`x64`, `x86`, `ARM64`).
- Remove tracked generated assembly-attributes output file from `WebRtcInterop.UnitTests` output tree.

Closes #27