### PR TITLE
Reduce duplicated WebRtcInterop configuration

### DIFF
--- a/WebRtcInterop.UnitTests/WebRtcInterop.UnitTests.vcxproj
+++ b/WebRtcInterop.UnitTests/WebRtcInterop.UnitTests.vcxproj
@@ -33,14 +33,14 @@
     <ConfigurationType>Application</ConfigurationType>
     <PlatformToolset>v145</PlatformToolset>
     <CharacterSet>Unicode</CharacterSet>
-    <TargetFrameworkVersion>v4.8</TargetFrameworkVersion>
+    <TargetFrameworkVersion>4.8</TargetFrameworkVersion>
     <CLRSupport>true</CLRSupport>
     <IncludePath>$(MSBuildProjectDirectory)\..\WebRtcInterop;$(IncludePath)</IncludePath>
     <ManagedAssembly>true</ManagedAssembly>
   </PropertyGroup>
-  <Import Project="..\WebRtcInterop\WebRtcInterop.BuildPaths.props" />
   <Import Project="$(VCTargetsPath)\Microsoft.Cpp.Default.props" />
   <Import Project="$(VCTargetsPath)\Microsoft.Cpp.props" />
+  <Import Project="..\WebRtcInterop\WebRtcInterop.BuildPaths.props" />
   <ImportGroup Label="ExtensionSettings" />
   <ImportGroup Label="Shared">
     <Import Project="..\third-party\shared-items\googletest\googletest.vcxitems" Label="Shared" />

--- a/WebRtcInterop/WebRtcInterop.BuildPaths.props
+++ b/WebRtcInterop/WebRtcInterop.BuildPaths.props
@@ -11,5 +11,7 @@
     <!-- Treat artifacts as prebuilt when the env var says so OR when the repo-local artifact tree exists -->
     <WebRtcPrebuilt Condition="'$(WEBRTC_PREBUILT)' == '1' Or (Exists('$(MSBuildThisFileDirectory)..\third-party\google\webrtc\include') And Exists('$(MSBuildThisFileDirectory)..\third-party\google\webrtc\lib'))">1</WebRtcPrebuilt>
     <WebRtcPrebuilt Condition="'$(WebRtcPrebuilt)' == ''">0</WebRtcPrebuilt>
+    <OutDir>bin\$(Platform)\$(Configuration)\$(TargetFrameworkVersion)\</OutDir>
+    <IntDir>obj\$(Platform)\$(Configuration)\$(TargetFrameworkVersion)\</IntDir>
   </PropertyGroup>
 </Project>

--- a/WebRtcInterop/WebRtcInterop.BuildPaths.props
+++ b/WebRtcInterop/WebRtcInterop.BuildPaths.props
@@ -11,7 +11,7 @@
     <!-- Treat artifacts as prebuilt when the env var says so OR when the repo-local artifact tree exists -->
     <WebRtcPrebuilt Condition="'$(WEBRTC_PREBUILT)' == '1' Or (Exists('$(MSBuildThisFileDirectory)..\third-party\google\webrtc\include') And Exists('$(MSBuildThisFileDirectory)..\third-party\google\webrtc\lib'))">1</WebRtcPrebuilt>
     <WebRtcPrebuilt Condition="'$(WebRtcPrebuilt)' == ''">0</WebRtcPrebuilt>
-    <OutDir>bin\$(Platform)\$(Configuration)\$(TargetFrameworkVersion)\</OutDir>
-    <IntDir>obj\$(Platform)\$(Configuration)\$(TargetFrameworkVersion)\</IntDir>
+    <OutDir>bin\$(Platform)\$(Configuration)\$(TargetFrameworkVersion)$(TargetFramework)\</OutDir>
+    <IntDir>obj\$(Platform)\$(Configuration)\$(TargetFrameworkVersion)$(TargetFramework)\</IntDir>
   </PropertyGroup>
 </Project>

--- a/WebRtcInterop/WebRtcInterop.Core.vcxproj
+++ b/WebRtcInterop/WebRtcInterop.Core.vcxproj
@@ -31,7 +31,6 @@
     <ProjectGuid>{F259D9C3-8B07-4B62-A9B8-F0836178BC58}</ProjectGuid>
     <Keyword>NetCoreCProj</Keyword>
     <TargetFramework>net10.0</TargetFramework>
-    <TargetFrameworkVersion>net10.0</TargetFrameworkVersion>
     <CLRSupport>NetCore</CLRSupport>
   </PropertyGroup>
   <Import Project="$(VCTargetsPath)\Microsoft.Cpp.Default.props" />

--- a/WebRtcInterop/WebRtcInterop.Framework.vcxproj
+++ b/WebRtcInterop/WebRtcInterop.Framework.vcxproj
@@ -30,7 +30,7 @@
     <VCProjectVersion>17.0</VCProjectVersion>
     <ProjectGuid>{26F36298-7F6A-4BD1-893B-2572BA180259}</ProjectGuid>
     <Keyword>NetCoreCProj</Keyword>
-    <TargetFrameworkVersion>4.8</TargetFrameworkVersion>
+    <TargetFrameworkVersion>v4.8</TargetFrameworkVersion>
     <CLRSupport>true</CLRSupport>
   </PropertyGroup>
   <Import Project="$(VCTargetsPath)\Microsoft.Cpp.Default.props" />

--- a/WebRtcInterop/WebRtcInterop.Shared.vcxitems
+++ b/WebRtcInterop/WebRtcInterop.Shared.vcxitems
@@ -50,6 +50,12 @@ ninja -C "$(WebRtcOutRoot)\$(Configuration)\$(Platform)"
       <PreprocessorDefinitions>ARM64;%(PreprocessorDefinitions)</PreprocessorDefinitions>
     </ClCompile>
   </ItemDefinitionGroup>
+  <!-- ARM64 webrtc.lib is built with iterator debugging disabled. -->
+  <ItemDefinitionGroup Condition="'$(Platform)'=='ARM64'">
+    <ClCompile>
+      <PreprocessorDefinitions>%(PreprocessorDefinitions);_ITERATOR_DEBUG_LEVEL=0</PreprocessorDefinitions>
+    </ClCompile>
+  </ItemDefinitionGroup>
   <ItemDefinitionGroup>
     <ClCompile>
       <ExternalIncludePath>%(ExternalIncludePath);$(WebRtcSrcRoot);$(WebRtcSrcRoot)\system_wrappers;$(WebRtcSrcRoot)\third_party\abseil-cpp;$(WebRtcSrcRoot)\buildtools\third_party\libc++;$(WebRtcSrcRoot)\third_party\libyuv\include;$(WebRtcSrcRoot)\third_party\jsoncpp\source\include</ExternalIncludePath>

--- a/WebRtcInterop/WebRtcInterop.default.props
+++ b/WebRtcInterop/WebRtcInterop.default.props
@@ -6,8 +6,6 @@
     <ConfigurationType>DynamicLibrary</ConfigurationType>
     <PlatformToolset>v145</PlatformToolset>
     <CharacterSet>Unicode</CharacterSet>
-    <OutDir>bin\$(Platform)\$(Configuration)\$(TargetFrameworkVersion)\</OutDir>
-    <IntDir>obj\$(Platform)\$(Configuration)\$(TargetFrameworkVersion)\</IntDir>
   </PropertyGroup>
   <PropertyGroup Condition="'$(Configuration)'=='Debug'" Label="Configuration">
     <UseDebugLibraries>true</UseDebugLibraries>

--- a/WebRtcNet.slnx
+++ b/WebRtcNet.slnx
@@ -1,7 +1,5 @@
 <Solution>
   <Configurations>
-    <BuildType Name="Debug" />
-    <BuildType Name="Release" />
     <Platform Name="ARM64" />
     <Platform Name="x64" />
     <Platform Name="x86" />
@@ -19,32 +17,15 @@
     <File Path="docker/build-webrtcnet.ps1" />
   </Folder>
   <Folder Name="/Interop/">
-    <Project Path="WebRtcInterop.UnitTests/WebRtcInterop.UnitTests.vcxproj" Id="5cfb4d3d-2e45-4a55-91ca-e45b7db34bf7">
-    </Project>
-    <Project Path="WebRtcInterop/WebRtcInterop.Core.vcxproj" Id="f259d9c3-8b07-4b62-a9b8-f0836178bc58">
-      <Platform Solution="*|x64" Project="x64" />
-      <Platform Solution="*|x86" Project="Win32" />
-      <Platform Solution="*|ARM64" Project="ARM64" />
-    </Project>
-    <Project Path="WebRtcInterop/WebRtcInterop.Framework.vcxproj" Id="26f36298-7f6a-4bd1-893b-2572ba180259">
-      <Platform Solution="*|x64" Project="x64" />
-      <Platform Solution="*|x86" Project="Win32" />
-      <Platform Solution="*|ARM64" Project="ARM64" />
-    </Project>
+    <Project Path="WebRtcInterop.UnitTests/WebRtcInterop.UnitTests.vcxproj" Id="5cfb4d3d-2e45-4a55-91ca-e45b7db34bf7" />
+    <Project Path="WebRtcInterop/WebRtcInterop.Core.vcxproj" Id="f259d9c3-8b07-4b62-a9b8-f0836178bc58" />
+    <Project Path="WebRtcInterop/WebRtcInterop.Framework.vcxproj" Id="26f36298-7f6a-4bd1-893b-2572ba180259" />
     <Project Path="WebRtcInterop/WebRtcInterop.Shared.vcxitems" Id="fac2e2bf-5a09-428f-a224-1ce7a160a2d1" />
   </Folder>
   <Folder Name="/third_party/">
     <Project Path="third-party/shared-items/googletest/googletest.vcxitems" Id="357b6b66-ab73-41cd-9271-1b4e5c41dde1" />
   </Folder>
-  <Project Path="WebRtcNet.Api.UnitTests/WebRtcNet.Api.UnitTests.csproj">
-  </Project>
-  <Project Path="WebRtcNet.Api/WebRtcNet.Api.csproj">
-    <BuildType Solution="Debug|ARM64" Project="Debug - .Net Core" />
-  </Project>
-  <Project Path="WebRtcNet/WebRtcNet.csproj">
-    <BuildType Solution="Debug|ARM64" Project="Debug - .Net Core" />
-    <Platform Solution="*|x64" Project="x64" />
-    <Platform Solution="*|x86" Project="x86" />
-    <Platform Solution="*|ARM64" Project="ARM64" />
-  </Project>
+  <Project Path="WebRtcNet.Api.UnitTests/WebRtcNet.Api.UnitTests.csproj" />
+  <Project Path="WebRtcNet.Api/WebRtcNet.Api.csproj" />
+  <Project Path="WebRtcNet/WebRtcNet.csproj" />
 </Solution>


### PR DESCRIPTION
## Summary
Reduce duplicated configuration across WebRtcInterop projects and solution mappings.

## Changes
- Move shared native OutDir/IntDir ownership into `WebRtcInterop.BuildPaths.props` and remove duplicates from `WebRtcInterop.default.props`.
- Align `WebRtcInterop.UnitTests.vcxproj` import placement with shared property flow.
- Add ARM64 iterator-debug compatibility define in shared interop items.
- Simplify solution-level project/config mapping entries in `WebRtcNet.slnx`.

## Coverage verification
PR #30 for issue #26 and PR #31 for issue #27 were created at the same time as this PR. Some changes that really should have been in there may have slipped into here. However, the mixed-change stash set has been fully accounted for.

Closes #28