### PR TITLE
Fix post-Phase1 WebRtcNet.Api spec alignment gaps

### DIFF
--- a/WebRtcNet.Api.UnitTests/MediaTrackConstraintTests.cs
+++ b/WebRtcNet.Api.UnitTests/MediaTrackConstraintTests.cs
@@ -66,6 +66,14 @@ public class MediaTrackConstraintTests
 	}
 
 	[Test]
+	public void MediaTrackSettings_Does_Not_Expose_Volume()
+	{
+		var property = typeof(MediaTrackSettings).GetProperty("Volume");
+
+		Assert.That(property, Is.Null);
+	}
+
+	[Test]
 	public void MediaTrackSettings_Defaults_AutoGainControl_To_Null()
 	{
 		var settings = new MediaTrackSettings();

--- a/WebRtcNet.Api.UnitTests/RtcOfferOptionsTests.cs
+++ b/WebRtcNet.Api.UnitTests/RtcOfferOptionsTests.cs
@@ -24,15 +24,32 @@ public class RtcOfferOptionsTests
 	}
 
 	[Test]
-	public void RtcOfferOptions_Does_Not_Expose_Legacy_Offer_To_Receive_Members()
+	public void RtcOfferOptions_Exposes_OfferToReceiveAudio_And_Video()
 	{
 		var type = typeof(RtcOfferOptions);
 
-		Assert.IsNull(type.GetProperty("OfferToReceiveAudio", BindingFlags.Public | BindingFlags.Instance));
-		Assert.IsNull(type.GetProperty("OfferToReceiveVideo", BindingFlags.Public | BindingFlags.Instance));
-		Assert.IsNull(type.GetField("Undefined", BindingFlags.Public | BindingFlags.Static));
-		Assert.IsNull(type.GetField("MaxOfferToReceiveMedia", BindingFlags.Public | BindingFlags.Static));
-		Assert.IsNull(type.GetField("OfferToReceiveTrue", BindingFlags.Public | BindingFlags.Static));
-		Assert.IsNull(type.GetField("OfferToReceiveFalse", BindingFlags.Public | BindingFlags.Static));
+		var audioProperty = type.GetProperty("OfferToReceiveAudio", BindingFlags.Public | BindingFlags.Instance);
+		var videoProperty = type.GetProperty("OfferToReceiveVideo", BindingFlags.Public | BindingFlags.Instance);
+
+		Assert.IsNotNull(audioProperty);
+		Assert.IsNotNull(videoProperty);
+	}
+
+	[Test]
+	public void RtcOfferOptions_OfferToReceive_Properties_Default_To_False()
+	{
+		var options = new RtcOfferOptions();
+
+		Assert.IsFalse(options.OfferToReceiveAudio);
+		Assert.IsFalse(options.OfferToReceiveVideo);
+	}
+
+	[Test]
+	public void RtcOfferOptions_OfferToReceive_Properties_Can_Be_Set()
+	{
+		var options = new RtcOfferOptions { OfferToReceiveAudio = true, OfferToReceiveVideo = true };
+
+		Assert.IsTrue(options.OfferToReceiveAudio);
+		Assert.IsTrue(options.OfferToReceiveVideo);
 	}
 }

--- a/WebRtcNet.Api.UnitTests/RtcStatsReportTests.cs
+++ b/WebRtcNet.Api.UnitTests/RtcStatsReportTests.cs
@@ -1,0 +1,205 @@
+using System;
+using NUnit.Framework;
+
+namespace WebRtcNet.Api.UnitTests;
+
+[TestFixture]
+public class RtcRtpStreamStatsTests
+{
+	[Test]
+	public void RtcRtpStreamStats_Ssrc_Exists()
+	{
+		var property = typeof(RtcRtpStreamStats).GetProperty("Ssrc");
+		Assert.IsNotNull(property, "Ssrc property should exist on RtcRtpStreamStats");
+	}
+
+	[Test]
+	public void RtcRtpStreamStats_Ssrc_Renamed_From_Src()
+	{
+		// Ensure old 'Src' property no longer exists
+		var srcProperty = typeof(RtcRtpStreamStats).GetProperty("Src");
+		Assert.IsNull(srcProperty, "Src property should be renamed to Ssrc");
+	}
+
+	[Test]
+	public void RtcRtpStreamStats_Kind_Property_Exists()
+	{
+		var property = typeof(RtcRtpStreamStats).GetProperty("Kind");
+		Assert.IsNotNull(property, "Kind property should exist on RtcRtpStreamStats");
+		Assert.AreEqual(typeof(string), property!.PropertyType, "Kind should be string");
+	}
+
+	[Test]
+	public void RtcRtpStreamStats_TransportId_Property_Exists()
+	{
+		var property = typeof(RtcRtpStreamStats).GetProperty("TransportId");
+		Assert.IsNotNull(property, "TransportId property should exist on RtcRtpStreamStats");
+		Assert.AreEqual(typeof(string), property!.PropertyType, "TransportId should be string");
+	}
+
+	[Test]
+	public void RtcRtpStreamStats_CodecId_Property_Exists()
+	{
+		var property = typeof(RtcRtpStreamStats).GetProperty("CodecId");
+		Assert.IsNotNull(property, "CodecId property should exist on RtcRtpStreamStats");
+		Assert.AreEqual(typeof(string), property!.PropertyType, "CodecId should be string");
+	}
+
+	[Test]
+	public void RtcRtpStreamStats_String_Properties_Default_To_Empty()
+	{
+		var stats = new RtcInboundRtpStreamStats();
+
+		Assert.AreEqual(string.Empty, stats.Kind);
+		Assert.AreEqual(string.Empty, stats.TransportId);
+		Assert.AreEqual(string.Empty, stats.CodecId);
+	}
+}
+
+[TestFixture]
+public class RtcInboundRtpStreamStatsTests
+{
+	[Test]
+	public void RtcInboundRtpStreamStats_PacketsReceived_Exists()
+	{
+		var property = typeof(RtcInboundRtpStreamStats).GetProperty("PacketsReceived");
+		Assert.IsNotNull(property, "PacketsReceived property should exist on RtcInboundRtpStreamStats");
+	}
+
+	[Test]
+	public void RtcInboundRtpStreamStats_BytesReceived_Exists()
+	{
+		var property = typeof(RtcInboundRtpStreamStats).GetProperty("BytesReceived");
+		Assert.IsNotNull(property, "BytesReceived property should exist on RtcInboundRtpStreamStats");
+	}
+
+	[Test]
+	public void RtcInboundRtpStreamStats_No_PacketsSent()
+	{
+		var property = typeof(RtcInboundRtpStreamStats).GetProperty("PacketsSent");
+		Assert.IsNull(property, "PacketsSent should not exist on RtcInboundRtpStreamStats (inbound should not send)");
+	}
+
+	[Test]
+	public void RtcInboundRtpStreamStats_No_BytesSent()
+	{
+		var property = typeof(RtcInboundRtpStreamStats).GetProperty("BytesSent");
+		Assert.IsNull(property, "BytesSent should not exist on RtcInboundRtpStreamStats (inbound should not send)");
+	}
+
+	[Test]
+	public void RtcInboundRtpStreamStats_PacketsReceived_Type()
+	{
+		var property = typeof(RtcInboundRtpStreamStats).GetProperty("PacketsReceived");
+		Assert.AreEqual(typeof(ulong), property!.PropertyType, "PacketsReceived should be of type ulong");
+	}
+
+	[Test]
+	public void RtcInboundRtpStreamStats_BytesReceived_Type()
+	{
+		var property = typeof(RtcInboundRtpStreamStats).GetProperty("BytesReceived");
+		Assert.AreEqual(typeof(ulong), property!.PropertyType, "BytesReceived should be of type ulong");
+	}
+
+	[Test]
+	public void RtcInboundRtpStreamStats_Create_With_Values()
+	{
+		var stats = new RtcInboundRtpStreamStats
+		{
+			Timestamp = TimeSpan.FromMilliseconds(100),
+			Type = RtcStatsType.InboundRtp,
+			Id = "inbound-123",
+			Ssrc = "3876931414",
+			Kind = "audio",
+			TransportId = "transport-1",
+			CodecId = "codec-audio-1",
+			PacketsReceived = 1000UL,
+			BytesReceived = 50000UL,
+			RemoteId = "outbound-456"
+		};
+
+		Assert.AreEqual(1000UL, stats.PacketsReceived);
+		Assert.AreEqual(50000UL, stats.BytesReceived);
+		Assert.AreEqual("3876931414", stats.Ssrc);
+		Assert.AreEqual("audio", stats.Kind);
+	}
+}
+
+[TestFixture]
+public class RtcOutboundRtpStreamStatsTests
+{
+	[Test]
+	public void RtcOutboundRtpStreamStats_PacketsSent_Type()
+	{
+		var property = typeof(RtcOutboundRtpStreamStats).GetProperty("PacketsSent");
+		Assert.IsNotNull(property, "PacketsSent property should exist on RtcOutboundRtpStreamStats");
+		Assert.AreEqual(typeof(ulong), property!.PropertyType, "PacketsSent should be of type ulong");
+	}
+
+	[Test]
+	public void RtcOutboundRtpStreamStats_BytesSent_Type()
+	{
+		var property = typeof(RtcOutboundRtpStreamStats).GetProperty("BytesSent");
+		Assert.IsNotNull(property, "BytesSent property should exist on RtcOutboundRtpStreamStats");
+		Assert.AreEqual(typeof(ulong), property!.PropertyType, "BytesSent should be of type ulong");
+	}
+
+	[Test]
+	public void RtcOutboundRtpStreamStats_PacketsSent_Is_Not_Int()
+	{
+		var property = typeof(RtcOutboundRtpStreamStats).GetProperty("PacketsSent");
+		Assert.AreNotEqual(typeof(int), property!.PropertyType, "PacketsSent should not be int");
+	}
+
+	[Test]
+	public void RtcOutboundRtpStreamStats_BytesSent_Is_Not_Int()
+	{
+		var property = typeof(RtcOutboundRtpStreamStats).GetProperty("BytesSent");
+		Assert.AreNotEqual(typeof(int), property!.PropertyType, "BytesSent should not be int");
+	}
+
+	[Test]
+	public void RtcOutboundRtpStreamStats_Create_With_Large_Values()
+	{
+		// Test that ulong can handle large values
+		var stats = new RtcOutboundRtpStreamStats
+		{
+			Timestamp = TimeSpan.FromMilliseconds(100),
+			Type = RtcStatsType.OutboundRtp,
+			Id = "outbound-123",
+			Ssrc = "3876931414",
+			Kind = "video",
+			TransportId = "transport-1",
+			CodecId = "codec-video-1",
+			PacketsSent = 18446744073709551615UL,  // Max ulong value
+			BytesSent = 18446744073709551615UL,    // Max ulong value
+			RemoteId = "inbound-456"
+		};
+
+		Assert.AreEqual(18446744073709551615UL, stats.PacketsSent);
+		Assert.AreEqual(18446744073709551615UL, stats.BytesSent);
+		Assert.AreEqual("3876931414", stats.Ssrc);
+		Assert.AreEqual("video", stats.Kind);
+	}
+
+	[Test]
+	public void RtcOutboundRtpStreamStats_Create_With_Standard_Values()
+	{
+		var stats = new RtcOutboundRtpStreamStats
+		{
+			Timestamp = TimeSpan.FromMilliseconds(100),
+			Type = RtcStatsType.OutboundRtp,
+			Id = "outbound-456",
+			Ssrc = "1234567890",
+			Kind = "video",
+			TransportId = "transport-2",
+			CodecId = "codec-video-2",
+			PacketsSent = 5000UL,
+			BytesSent = 2500000UL,
+			RemoteId = "inbound-789"
+		};
+
+		Assert.AreEqual(5000UL, stats.PacketsSent);
+		Assert.AreEqual(2500000UL, stats.BytesSent);
+	}
+}

--- a/WebRtcNet.Api.UnitTests/RtpContractTests.cs
+++ b/WebRtcNet.Api.UnitTests/RtpContractTests.cs
@@ -121,6 +121,7 @@ public class RtpContractTests
 		Assert.IsNotNull(receiverMethod);
 		Assert.AreEqual(typeof(RtcRtpCapabilities), senderMethod!.ReturnType);
 		Assert.AreEqual(typeof(RtcRtpCapabilities), receiverMethod!.ReturnType);
+		Assert.AreEqual(2, GetNullableFlag(receiverMethod.ReturnParameter));
 	}
 
 	[Test]

--- a/WebRtcNet.Api/Media/MediaTrackConstraints.ConstraintTypes.cs
+++ b/WebRtcNet.Api/Media/MediaTrackConstraints.ConstraintTypes.cs
@@ -114,12 +114,10 @@ public partial class MediaTrackConstraints
 	/// </summary>
 	/// <seealso href="https://www.w3.org/TR/mediacapture-streams/#dom-constrainulongrange" />
 	/// <seealso href="https://www.w3.org/TR/mediacapture-streams/#dom-constrainedoublerange" />
-	public class RangeConstraint<T> where T : struct, IComparable<T>
+	public class RangeConstraint<T> : ValueRange<T> where T : struct, IComparable<T>
 	{
 		private T? _ideal;
 		private T? _exact;
-		private T? _min;
-		private T? _max;
 
 		/// <summary>
 		/// Preferred value.
@@ -150,12 +148,12 @@ public partial class MediaTrackConstraints
 		/// <summary>
 		/// Inclusive minimum bound.
 		/// </summary>
-		public T? Min
+		public new T? Min
 		{
-			get => _min;
+			get => base.Min;
 			set
 			{
-				_min = value;
+				base.Min = value;
 				ValidateState();
 			}
 		}
@@ -163,12 +161,12 @@ public partial class MediaTrackConstraints
 		/// <summary>
 		/// Inclusive maximum bound.
 		/// </summary>
-		public T? Max
+		public new T? Max
 		{
-			get => _max;
+			get => base.Max;
 			set
 			{
-				_max = value;
+				base.Max = value;
 				ValidateState();
 			}
 		}
@@ -190,6 +188,7 @@ public partial class MediaTrackConstraints
 		/// </summary>
 		/// <param name="value">Exact value.</param>
 		public RangeConstraint(T value)
+			: this()
 		{
 			Exact = value;
 		}
@@ -199,6 +198,7 @@ public partial class MediaTrackConstraints
 		/// </summary>
 		/// <param name="value">Source constraint.</param>
 		public RangeConstraint(Constraint<T> value)
+			: this()
 		{
 			Exact = value.Exact;
 			Ideal = value.Ideal;
@@ -211,6 +211,7 @@ public partial class MediaTrackConstraints
 		/// <param name="max">Inclusive maximum bound.</param>
 		/// <param name="ideal">Preferred value.</param>
 		public RangeConstraint(T min, T max, T ideal)
+			: this()
 		{
 			Min = min;
 			Max = max;
@@ -222,10 +223,11 @@ public partial class MediaTrackConstraints
 		/// </summary>
 		/// <param name="valueRange">Value range source.</param>
 		public RangeConstraint(ValueRange<T> valueRange)
+			: this()
 		{
 			Min = valueRange.Min;
 			Max = valueRange.Max;
-			if (Max.Equals(Min))
+			if (Max.HasValue && Min.HasValue && Max.Value.Equals(Min.Value))
 				Exact = Max;
 		}
 

--- a/WebRtcNet.Api/Media/MediaTrackSettings.cs
+++ b/WebRtcNet.Api/Media/MediaTrackSettings.cs
@@ -5,7 +5,7 @@ namespace WebRtcNet.Media;
 /// <see cref="MediaStreamTrack" /> object. This is an out-only snapshot returned by
 /// <see cref="MediaStreamTrack.GetSettings" />.
 /// </summary>
-/// <seealso href="http://www.w3.org/TR/mediacapture-streams/#media-track-settings" />
+/// <seealso href="https://www.w3.org/TR/mediacapture-streams/#media-track-settings" />
 public sealed record MediaTrackSettings
 {
 	/// <summary>
@@ -45,12 +45,6 @@ public sealed record MediaTrackSettings
 	/// <seealso href="https://www.w3.org/TR/mediacapture-streams/#def-constraint-resizeMode" />
 	/// <seealso href="https://www.w3.org/TR/mediacapture-streams/#dom-mediatracksettings-resizemode" />
 	public VideoResizeModes? ResizeMode { get; init; }
-
-	/// <summary>
-	/// Current volume setting for the track.
-	/// </summary>
-	/// <seealso href="https://www.w3.org/TR/mediacapture-streams/#def-constraint-volume" />
-	public double Volume { get; init; }
 
 	/// <summary>
 	/// Current audio sample rate setting for the track.

--- a/WebRtcNet.Api/RtcDataChannel.cs
+++ b/WebRtcNet.Api/RtcDataChannel.cs
@@ -16,18 +16,18 @@ public record RtcDataChannelInit
 	public ushort? Id { get; init; } = null;
 
 	/// <summary>
-	/// Limits the time during which the channel will transmit or retransmit data if not acknowledged. This value may be
+	/// Limits the time during which the channel will transmit or retransmit data if not acknowledged, in milliseconds. This value may be
 	/// clamped if it exceeds the maximum value supported by the platform.
 	/// </summary>
 	/// <seealso href="https://www.w3.org/TR/webrtc/#dom-rtcdatachannelinit-maxpacketlifetime" />
-	public uint? MaxPacketLifeTime { get; init; } = null;
+	public ushort? MaxPacketLifeTime { get; init; } = null;
 
 	/// <summary>
 	/// Limits the number of times a channel will retransmit data if not successfully delivered. This value may be clamped
 	/// if it exceeds the maximum value supported by the platform.
 	/// </summary>
 	/// <seealso href="https://www.w3.org/TR/webrtc/#dom-rtcdatachannelinit-maxretransmits" />
-	public uint? MaxRetransmits { get; init; } = null;
+	public ushort? MaxRetransmits { get; init; } = null;
 
 	/// <summary>
 	/// The default value of false tells the platform to announce the channel in-band and instruct the other peer to
@@ -123,14 +123,14 @@ public abstract class RtcDataChannel
 	/// retransmissions may occur in unreliable mode, or null if unset.
 	/// </summary>
 	/// <seealso href="https://www.w3.org/TR/webrtc/#dom-datachannel-maxpacketlifetime" />
-	public abstract uint? MaxPacketLifeTime { get; }
+	public abstract ushort? MaxPacketLifeTime { get; }
 
 	/// <summary>
 	/// MaxRetransmits returns the maximum number of retransmissions that are attempted in unreliable mode, or null if
 	/// unset.
 	/// </summary>
 	/// <seealso href="https://www.w3.org/TR/webrtc/#dom-datachannel-maxretransmits" />
-	public abstract uint? MaxRetransmits { get; }
+	public abstract ushort? MaxRetransmits { get; }
 
 	/// <summary>
 	/// Protocol returns the name of the sub-protocol used with this RtcDataChannel if any, or the empty string otherwise.
@@ -252,6 +252,50 @@ public abstract class RtcDataChannel
 	/// <param name="data">An array of bytes to send to the peer.</param>
 	/// <seealso href="https://www.w3.org/TR/webrtc/#dom-rtcdatachannel-send" />
 	public abstract void Send(byte[] data);
+
+	/// <summary>
+	/// Send byte data through the data channel to a peer.
+	/// </summary>
+	/// <param name="data">A segment of bytes to send to the peer.</param>
+	/// <seealso href="https://www.w3.org/TR/webrtc/#dom-rtcdatachannel-send" />
+	public virtual void Send(ArraySegment<byte> data)
+	{
+		if (data.Array is null)
+			throw new ArgumentException("ArraySegment must reference a backing array.", nameof(data));
+
+		if (data.Offset == 0 && data.Count == data.Array.Length)
+		{
+			Send(data.Array);
+			return;
+		}
+
+		var payload = new byte[data.Count];
+		Array.Copy(data.Array, data.Offset, payload, 0, data.Count);
+		Send(payload);
+	}
+
+	/// <summary>
+	/// Send byte data through the data channel to a peer.
+	/// </summary>
+	/// <param name="data">A read-only collection of bytes to send to the peer.</param>
+	/// <seealso href="https://www.w3.org/TR/webrtc/#dom-rtcdatachannel-send" />
+	public virtual void Send(IReadOnlyList<byte> data)
+	{
+		if (data is null)
+			throw new ArgumentNullException(nameof(data));
+
+		if (data is byte[] bytes)
+		{
+			Send(bytes);
+			return;
+		}
+
+		var payload = new byte[data.Count];
+		for (var i = 0; i < data.Count; i++)
+			payload[i] = data[i];
+
+		Send(payload);
+	}
 }
 
 /// <summary>

--- a/WebRtcNet.Api/RtcDtlsTransport.cs
+++ b/WebRtcNet.Api/RtcDtlsTransport.cs
@@ -38,7 +38,7 @@ public enum RtcDtlsTransportState
 	Closed,
 
 	/// <summary>
-	/// 
+	/// DTLS negotiation failed and the transport can no longer be used.
 	/// </summary>
 	/// <seealso href="https://www.w3.org/TR/webrtc/#dom-rtcdtlstransportstate-failed"/>
 	Failed
@@ -93,7 +93,7 @@ public abstract class RtcDtlsTransport
 	public abstract IEnumerator<byte[]> GetRemoteCertificates();
 
 	/// <summary>
-	/// Fired when the RTCSctpTransport <see cref="State"/> changes.
+	/// Fired when the RTCDtlsTransport <see cref="State"/> changes.
 	/// </summary>
 	public abstract event EventHandler OnStateChange;
 

--- a/WebRtcNet.Api/RtcDtmfSender.cs
+++ b/WebRtcNet.Api/RtcDtmfSender.cs
@@ -1,5 +1,4 @@
 using System;
-using WebRtcNet.Media;
 
 namespace WebRtcNet;
 
@@ -25,6 +24,7 @@ public abstract class RtcDtmfSender
 	/// <summary>
 	/// Indicates if the RTCDTMFSender is capable of sending DTMF.
 	/// </summary>
+	/// <seealso href="https://www.w3.org/TR/webrtc/#dom-rtcdtmfsender-caninsertdtmf"/>
 	public abstract bool CanInsertDtmf { get; }
 
 	/// <summary>
@@ -39,43 +39,30 @@ public abstract class RtcDtmfSender
 	/// boundaries of RTP packets but it will not increase either of them by more than the duration of a single RTP audio packet.
 	/// </summary>
 	/// <param name="tones">A series of characters that represent DTMF tones to be sent.</param>
-	/// <param name="duration">The duration in ms to use for each character passed in the tones parameters.</param>
-	/// <param name="interToneGap">The duration in ms for the gap between tones</param>
-	public abstract void InsertDtmf(string tones, long duration = 100, long interToneGap = 70);
-
-	/// <summary>
-	/// The MediaStreamTrack given as argument to the RtcPeerConnection.CreateDtmfSender() method.
-	/// </summary>
-	public abstract MediaStreamTrack Track { get; }
+	/// <param name="duration">The duration in milliseconds to use for each character passed in the tones parameters.</param>
+	/// <param name="interToneGap">The duration in milliseconds for the gap between tones.</param>
+	/// <seealso href="https://www.w3.org/TR/webrtc/#dom-rtcdtmfsender-insertdtmf"/>
+	public abstract void InsertDtmf(string tones, uint duration = 100, uint interToneGap = 70);
 
 	/// <summary>
 	/// Fired for each tone as it is played out.
 	/// </summary>
+	/// <seealso href="https://www.w3.org/TR/webrtc/#dom-rtcdtmfsender-ontonechange"/>
 	public abstract event EventHandler<RtcDtmfToneChangedEventArgs> OnToneChange;
 
 	/// <summary>
 	/// A list of the tones remaining to be played out. For the syntax, content, and interpretation of this list, see 
 	/// <see cref="InsertDtmf"/>
 	/// </summary>
+	/// <seealso href="https://www.w3.org/TR/webrtc/#dom-RTCDTMFSender-tonebuffer"/>
 	public abstract string ToneBuffer { get; }
-
-	/// <summary>
-	/// The current tone duration value. This value will be the value last set via the InsertDtmf() method, 
-	/// or the default value of 100 ms if InsertDtmf() was called without specifying the duration.
-	/// </summary>
-	public abstract int Duration { get; }
-
-	/// <summary>
-	/// the current value of the between-tone gap. This value will be the value last set via the InsertDtmf() method, or the 
-	/// default value of 70 ms if InsertDtmf() was called without specifying the interToneGap.
-	/// </summary>
-	public abstract int InterToneGap { get; }
 }
 
 /// <summary>
 /// Event data for <see cref="RtcDtmfSender.OnToneChange" />.
 /// </summary>
 /// <seealso href="https://www.w3.org/TR/webrtc/#event-dtmfsender-tonechange" />
+/// <seealso href="https://www.w3.org/TR/webrtc/#dom-rtcdtmftonechangeevent-tone" />
 public class RtcDtmfToneChangedEventArgs : EventArgs
 {
 	/// <summary>
@@ -90,5 +77,6 @@ public class RtcDtmfToneChangedEventArgs : EventArgs
 	/// <summary>
 	/// Gets the tone value for the event.
 	/// </summary>
+	/// <seealso href="https://www.w3.org/TR/webrtc/#dom-rtcdtmftonechangeevent-tone" />
 	public string Tone { get; }
 }

--- a/WebRtcNet.Api/RtcError.cs
+++ b/WebRtcNet.Api/RtcError.cs
@@ -105,8 +105,8 @@ public class RtcError : Exception
     public long? SctpCauseCode { get; }
 
     /// <summary>
-    /// If <see cref="ErrorDetail"/> is <see cref="RtcErrorDetailType.DtlsFailure"/> his is the SCTP cause code of the failed SCTP
-    /// negotiation.
+    /// If <see cref="ErrorDetail"/> is <see cref="RtcErrorDetailType.DtlsFailure"/> and a fatal DTLS alert was received,
+    /// this is the value of that alert.
     /// </summary>
     /// <seealso href="https://www.w3.org/TR/webrtc/#dom-rtcerror-receivedalert"/>
     public ulong? ReceivedAlert { get; }

--- a/WebRtcNet.Api/RtcIceTransport.cs
+++ b/WebRtcNet.Api/RtcIceTransport.cs
@@ -254,67 +254,67 @@ public abstract class RtcIceTransport
 	public abstract RtcIceRole Role { get; }
 
 	/// <summary>
-	/// 
+	/// Gets the ICE component associated with this transport.
 	/// </summary>
 	/// <seealso href="https://www.w3.org/TR/webrtc/#dom-icetransport-component"/>
 	public abstract RtcIceComponent Component { get; }
 
 	/// <summary>
-	/// 
+	/// Gets the current ICE state for this transport.
 	/// </summary>
 	/// <seealso href="https://www.w3.org/TR/webrtc/#dom-icetransport-state"/>
 	public abstract RtcIceTransportState State { get; }
 
 	/// <summary>
-	/// 
+	/// Gets the current candidate gathering state for this transport.
 	/// </summary>
 	/// <seealso href="https://www.w3.org/TR/webrtc/#dom-icetransport-gatheringstate"/>
 	public abstract RtcIceGatheringState GatheringState { get; }
 
 	/// <summary>
-	/// 
+	/// Gets the list of local ICE candidates known by this transport.
 	/// </summary>
 	/// <seealso href="https://www.w3.org/TR/webrtc/#dom-rtcicetransport-getlocalcandidates"/>
 	public abstract IEnumerable<RtcIceCandidate> GetLocalCandidates();
 
 	/// <summary>
-	/// 
+	/// Gets the list of remote ICE candidates known by this transport.
 	/// </summary>
 	/// <seealso href="https://www.w3.org/TR/webrtc/#dom-rtcicetransport-getremotecandidates"/>
 	public abstract IEnumerable<RtcIceCandidate> GetRemoteCandidates();
 
 	/// <summary>
-	/// 
+	/// Gets the selected candidate pair currently used by this transport.
 	/// </summary>
 	/// <seealso href="https://www.w3.org/TR/webrtc/#dom-rtcicetransport-getselectedcandidatepair"/>
 	public abstract RtcIceCandidatePair GetSelectedCandidatePair();
 
 	/// <summary>
-	/// 
+	/// Gets the local ICE parameters negotiated for this transport.
 	/// </summary>
 	/// <seealso href="https://www.w3.org/TR/webrtc/#dom-rtcicetransport-getlocalparameters"/>
 	public abstract RtcIceParameters GetLocalParameters();
 
 	/// <summary>
-	/// 
+	/// Gets the remote ICE parameters negotiated for this transport.
 	/// </summary>
 	/// <seealso href="https://www.w3.org/TR/webrtc/#dom-rtcicetransport-getremoteparameters"/>
 	public abstract RtcIceParameters GetRemoteParameters();
 
 	/// <summary>
-	/// 
+	/// Raised when <see cref="State"/> changes.
 	/// </summary>
 	/// <seealso href="https://www.w3.org/TR/webrtc/#dom-rtcicetransport-onstatechange"/>
 	public abstract event EventHandler OnStateChange;
 
 	/// <summary>
-	/// 
+	/// Raised when <see cref="GatheringState"/> changes.
 	/// </summary>
 	/// <seealso href="https://www.w3.org/TR/webrtc/#dom-rtcicetransport-ongatheringstatechange"/>
 	public abstract event EventHandler OnGatheringStateChange;
 
 	/// <summary>
-	/// 
+	/// Raised when the selected ICE candidate pair changes.
 	/// </summary>
 	/// <seealso href="https://www.w3.org/TR/webrtc/#dom-rtcicetransport-onselectedcandidatepairchange"/>
 	public abstract event EventHandler OnSelectedCandidatePairChange;

--- a/WebRtcNet.Api/RtcOfferOptions.cs
+++ b/WebRtcNet.Api/RtcOfferOptions.cs
@@ -21,6 +21,18 @@ public record RtcOfferOptions : RtcOfferAnswerOptions
 	/// </summary>
 	/// <seealso href="https://www.w3.org/TR/webrtc/#dom-rtcofferoptions-icerestart" />
 	public bool IceRestart { get; init; } = false;
+
+	/// <summary>
+	/// When true, indicates the offer should include audio media.
+	/// </summary>
+	/// <seealso href="https://www.w3.org/TR/webrtc/#dom-rtcofferoptions-offertoreceiveaudio" />
+	public bool OfferToReceiveAudio { get; init; }
+
+	/// <summary>
+	/// When true, indicates the offer should include video media.
+	/// </summary>
+	/// <seealso href="https://www.w3.org/TR/webrtc/#dom-rtcofferoptions-offertoreceivevideo" />
+	public bool OfferToReceiveVideo { get; init; }
 }
 
 /// <summary>

--- a/WebRtcNet.Api/RtcRtpEncodingParameters.cs
+++ b/WebRtcNet.Api/RtcRtpEncodingParameters.cs
@@ -87,4 +87,5 @@ public sealed record RtcRtpEncodingParameters : RtcRtpCodingParameters
 	/// </summary>
 	/// <seealso href="https://www.w3.org/TR/webrtc/#dom-rtcrtpencodingparameters-scaleresolutiondownby"/>
 	public double ScaleResolutionDownBy { get; set; }
+
 }

--- a/WebRtcNet.Api/RtcRtpReceiver.cs
+++ b/WebRtcNet.Api/RtcRtpReceiver.cs
@@ -52,9 +52,9 @@ public abstract class RtcRtpReceiver
 	/// GetCapabilities returns null.
 	/// </summary>
 	/// <param name="kind">The type of media device for which to request capabilities.</param>
-	/// <returns>The RTP capabilities for the requested media <paramref name="kind"/>.</returns>
+	/// <returns>The RTP capabilities for the requested media <paramref name="kind"/>, or null if not supported.</returns>
 	/// <seealso href="https://www.w3.org/TR/webrtc/#dom-rtcrtpreceiver-getcapabilities"/>
-	public static RtcRtpCapabilities GetCapabilities(MediaStreamTrackKind kind)
+	public static RtcRtpCapabilities? GetCapabilities(MediaStreamTrackKind kind)
 	{
 		throw new NotSupportedException();
 	}

--- a/WebRtcNet.Api/RtcSctpTransport.cs
+++ b/WebRtcNet.Api/RtcSctpTransport.cs
@@ -62,6 +62,12 @@ public abstract class RtcSctpTransport
 	public abstract double MaxMessageSize { get; }
 
 	/// <summary>
+	/// Gets the maximum number of data channels that can be created, or null if unspecified.
+	/// </summary>
+	/// <seealso href="https://www.w3.org/TR/webrtc/#dom-rtcsctptransport-maxchannels"/>
+	public abstract ushort? MaxChannels { get; }
+
+	/// <summary>
 	/// Raised when <see cref="State"/> changes.
 	/// </summary>
 	/// <seealso href="https://www.w3.org/TR/webrtc/#event-rtcsctptransport-statechange"/>

--- a/WebRtcNet.Api/RtcStatsReport.cs
+++ b/WebRtcNet.Api/RtcStatsReport.cs
@@ -53,7 +53,26 @@ public abstract record RtcRtpStreamStats : RtcStats
 	/// <summary>
 	/// Gets the synchronization source identifier (SSRC) for the RTP stream.
 	/// </summary>
-	public string Src { get; init; } = string.Empty;
+	/// <seealso href="https://www.w3.org/TR/webrtc-stats/#dom-rtcrtpstreamstats-ssrc" />
+	public string Ssrc { get; init; } = string.Empty;
+
+	/// <summary>
+	/// The kind of the RTP stream, one of "audio" or "video".
+	/// </summary>
+	/// <seealso href="https://www.w3.org/TR/webrtc-stats/#dom-rtcrtpstreamstats-kind" />
+	public string Kind { get; init; } = string.Empty;
+
+	/// <summary>
+	/// The TransportId identifies the transport used to send or receive this RTP stream.
+	/// </summary>
+	/// <seealso href="https://www.w3.org/TR/webrtc-stats/#dom-rtcrtpstreamstats-transportid" />
+	public string TransportId { get; init; } = string.Empty;
+
+	/// <summary>
+	/// The CodecId identifies the RTP codec used by the RTP stream.
+	/// </summary>
+	/// <seealso href="https://www.w3.org/TR/webrtc-stats/#dom-rtcrtpstreamstats-codecid" />
+	public string CodecId { get; init; } = string.Empty;
 
 	/// <summary>
 	/// The remoteId can be used to look up the corresponding RTCStats object that represents stats reported by the other peer.
@@ -68,14 +87,16 @@ public abstract record RtcRtpStreamStats : RtcStats
 public sealed record RtcInboundRtpStreamStats : RtcRtpStreamStats
 {
 	/// <summary>
-	/// Gets the number of packets sent for this stream.
+	/// Gets the number of packets received for this stream.
 	/// </summary>
-	public uint PacketsSent { get; init; }
+	/// <seealso href="https://www.w3.org/TR/webrtc-stats/#dom-rtcinboundrtpstreamstats-packetsreceived" />
+	public ulong PacketsReceived { get; init; }
 
 	/// <summary>
-	/// Gets the number of bytes sent for this stream.
+	/// Gets the number of bytes received for this stream.
 	/// </summary>
-	public uint BytesSent { get; init; }
+	/// <seealso href="https://www.w3.org/TR/webrtc-stats/#dom-rtcinboundrtpstreamstats-bytesreceived" />
+	public ulong BytesReceived { get; init; }
 }
 
 /// <summary>
@@ -87,12 +108,14 @@ public sealed record RtcOutboundRtpStreamStats : RtcRtpStreamStats
 	/// <summary>
 	/// Gets the number of packets sent for this stream.
 	/// </summary>
-	public int PacketsSent { get; init; }
+	/// <seealso href="https://www.w3.org/TR/webrtc-stats/#dom-rtcoutboundrtpstreamstats-packetssent" />
+	public ulong PacketsSent { get; init; }
 
 	/// <summary>
 	/// Gets the number of bytes sent for this stream.
 	/// </summary>
-	public int BytesSent { get; init; }
+	/// <seealso href="https://www.w3.org/TR/webrtc-stats/#dom-rtcoutboundrtpstreamstats-bytessent" />
+	public ulong BytesSent { get; init; }
 }
 
 /// <summary>

--- a/WebRtcNet.Api/ValueRange.cs
+++ b/WebRtcNet.Api/ValueRange.cs
@@ -4,23 +4,32 @@
 /// Represents a minimum/maximum range for values of type <typeparamref name="T" />.
 /// </summary>
 /// <typeparam name="T">The value type represented by the range.</typeparam>
+/// <seealso href="https://www.w3.org/TR/mediacapture-streams/#dom-doublerange" />
+/// <seealso href="https://www.w3.org/TR/mediacapture-streams/#dom-ulongrange" />
 public class ValueRange<T> where T : struct
 {
 	/// <summary>
+	/// Initializes an empty range with no bounds set.
+	/// </summary>
+	public ValueRange()
+	{
+	}
+
+	/// <summary>
 	/// The upper bound of the range.
 	/// </summary>
-	public T Max;
+	public T? Max;
 
 	/// <summary>
 	/// The lower bound of the range.
 	/// </summary>
-	public T Min;
+	public T? Min;
 
 	/// <summary>
 	/// Initializes a range where <see cref="Min" /> and <see cref="Max" /> are equal to <paramref name="value" />.
 	/// </summary>
 	/// <param name="value">The single value for both bounds.</param>
-	public ValueRange(T value)
+	public ValueRange(T? value)
 	{
 		Min = Max = value;
 	}
@@ -30,7 +39,7 @@ public class ValueRange<T> where T : struct
 	/// </summary>
 	/// <param name="min">The lower bound.</param>
 	/// <param name="max">The upper bound.</param>
-	public ValueRange(T min, T max)
+	public ValueRange(T? min, T? max)
 	{
 		Min = min;
 		Max = max;
@@ -43,7 +52,7 @@ public class ValueRange<T> where T : struct
 	/// <returns>The range's upper bound.</returns>
 	public static implicit operator T(ValueRange<T> from)
 	{
-		return from.Max;
+		return from.Max ?? from.Min ?? default(T);
 	}
 
 	/// <summary>

--- a/documents/specs/index/spec-map.json
+++ b/documents/specs/index/spec-map.json
@@ -3,16 +3,16 @@
 	"generatedOn": "2026-05-28",
 	"entries": [
 		{
-			"apiSymbol": "IRtcPeerConnection",
-			"apiFile": "WebRtcNet.Api/IRtcPeerConnection.cs",
+			"apiSymbol": "RtcPeerConnection",
+			"apiFile": "WebRtcNet.Api/RtcPeerConnection.cs",
 			"spec": "webrtc",
 			"anchor": "https://www.w3.org/TR/webrtc/#dom-rtcpeerconnection",
 			"status": "seeded",
 			"notes": "Primary peer connection contract surface."
 		},
 		{
-			"apiSymbol": "IRtcDataChannel",
-			"apiFile": "WebRtcNet.Api/IRtcDataChannel.cs",
+			"apiSymbol": "RtcDataChannel",
+			"apiFile": "WebRtcNet.Api/RtcDataChannel.cs",
 			"spec": "webrtc",
 			"anchor": "https://www.w3.org/TR/webrtc/#dom-rtcdatachannel",
 			"status": "seeded",
@@ -27,16 +27,16 @@
 			"notes": "ICE candidate model and parsed properties."
 		},
 		{
-			"apiSymbol": "IRtcRtpSender",
-			"apiFile": "WebRtcNet.Api/IRtcRtpSender.cs",
+			"apiSymbol": "RtcRtpSender",
+			"apiFile": "WebRtcNet.Api/RtcRtpSender.cs",
 			"spec": "webrtc",
 			"anchor": "https://www.w3.org/TR/webrtc/#dom-rtcrtpsender",
 			"status": "seeded",
 			"notes": "RTP sender behavior and parameter control."
 		},
 		{
-			"apiSymbol": "IRtcRtpTransceiver",
-			"apiFile": "WebRtcNet.Api/IRtcRtpTransceiver.cs",
+			"apiSymbol": "RtcRtpTransceiver",
+			"apiFile": "WebRtcNet.Api/RtcRtpTransceiver.cs",
 			"spec": "webrtc",
 			"anchor": "https://www.w3.org/TR/webrtc/#dom-rtcrtptransceiver",
 			"status": "seeded",
@@ -51,24 +51,24 @@
 			"notes": "Dictionary alignment requires deeper section mapping."
 		},
 		{
-			"apiSymbol": "IMediaDevices",
-			"apiFile": "WebRtcNet.Api/Media/IMediaDevices.cs",
+			"apiSymbol": "MediaDevices",
+			"apiFile": "WebRtcNet.Api/Media/MediaDevices.cs",
 			"spec": "mediacapture",
 			"anchor": "https://www.w3.org/TR/mediacapture-streams/#dom-mediadevices-getusermedia",
 			"status": "seeded",
 			"notes": "Device acquisition and permissions flow."
 		},
 		{
-			"apiSymbol": "IMediaStream",
-			"apiFile": "WebRtcNet.Api/Media/IMediaStream.cs",
+			"apiSymbol": "MediaStream",
+			"apiFile": "WebRtcNet.Api/Media/MediaStream.cs",
 			"spec": "mediacapture",
 			"anchor": "https://www.w3.org/TR/mediacapture-streams/#mediastream",
 			"status": "seeded",
 			"notes": "Media stream container model."
 		},
 		{
-			"apiSymbol": "IMediaStreamTrack",
-			"apiFile": "WebRtcNet.Api/Media/IMediaStreamTrack.cs",
+			"apiSymbol": "MediaStreamTrack",
+			"apiFile": "WebRtcNet.Api/Media/MediaStreamTrack.cs",
 			"spec": "mediacapture",
 			"anchor": "https://www.w3.org/TR/mediacapture-streams/#dom-mediastreamtrack-applyconstraints",
 			"status": "seeded",
@@ -107,8 +107,8 @@
 			"notes": "Top-level audio/video request constraints."
 		},
 		{
-			"apiSymbol": "IRtcStatsReport",
-			"apiFile": "WebRtcNet.Api/IRtcStatsReport.cs",
+			"apiSymbol": "RtcStats",
+			"apiFile": "WebRtcNet.Api/RtcStatsReport.cs",
 			"spec": "webrtc-stats",
 			"anchor": "https://www.w3.org/TR/webrtc-stats/#rtcstatsreport-object",
 			"status": "seeded",

--- a/documents/specs/index/spec-map.md
+++ b/documents/specs/index/spec-map.md
@@ -4,18 +4,18 @@ This file mirrors `spec-map.json` in a quick-readable format.
 
 | API Symbol | API File | Spec | Anchor | Status |
 | --- | --- | --- | --- | --- |
-| `IRtcPeerConnection` | `WebRtcNet.Api/IRtcPeerConnection.cs` | WebRTC | <https://www.w3.org/TR/webrtc/#dom-rtcpeerconnection> | seeded |
-| `IRtcDataChannel` | `WebRtcNet.Api/IRtcDataChannel.cs` | WebRTC | <https://www.w3.org/TR/webrtc/#dom-rtcdatachannel> | seeded |
+| `RtcPeerConnection` | `WebRtcNet.Api/RtcPeerConnection.cs` | WebRTC | <https://www.w3.org/TR/webrtc/#dom-rtcpeerconnection> | seeded |
+| `RtcDataChannel` | `WebRtcNet.Api/RtcDataChannel.cs` | WebRTC | <https://www.w3.org/TR/webrtc/#dom-rtcdatachannel> | seeded |
 | `RtcIceCandidate` | `WebRtcNet.Api/RtcIceCandidate.cs` | WebRTC | <https://www.w3.org/TR/webrtc/#dom-rtcicecandidate> | seeded |
-| `IRtcRtpSender` | `WebRtcNet.Api/IRtcRtpSender.cs` | WebRTC | <https://www.w3.org/TR/webrtc/#dom-rtcrtpsender> | seeded |
-| `IRtcRtpTransceiver` | `WebRtcNet.Api/IRtcRtpTransceiver.cs` | WebRTC | <https://www.w3.org/TR/webrtc/#dom-rtcrtptransceiver> | seeded |
+| `RtcRtpSender` | `WebRtcNet.Api/RtcRtpSender.cs` | WebRTC | <https://www.w3.org/TR/webrtc/#dom-rtcrtpsender> | seeded |
+| `RtcRtpTransceiver` | `WebRtcNet.Api/RtcRtpTransceiver.cs` | WebRTC | <https://www.w3.org/TR/webrtc/#dom-rtcrtptransceiver> | seeded |
 | `RtcRtpParameters` | `WebRtcNet.Api/RtcRtpParameters.cs` | WebRTC | <https://www.w3.org/TR/webrtc/#rtcrtpinterface> | seeded |
-| `IMediaDevices` | `WebRtcNet.Api/Media/IMediaDevices.cs` | Media Capture | <https://www.w3.org/TR/mediacapture-streams/#dom-mediadevices-getusermedia> | seeded |
-| `IMediaStream` | `WebRtcNet.Api/Media/IMediaStream.cs` | Media Capture | <https://www.w3.org/TR/mediacapture-streams/#mediastream> | seeded |
-| `IMediaStreamTrack` | `WebRtcNet.Api/Media/IMediaStreamTrack.cs` | Media Capture | <https://www.w3.org/TR/mediacapture-streams/#dom-mediastreamtrack-applyconstraints> | seeded |
+| `MediaDevices` | `WebRtcNet.Api/Media/MediaDevices.cs` | Media Capture | <https://www.w3.org/TR/mediacapture-streams/#dom-mediadevices-getusermedia> | seeded |
+| `MediaStream` | `WebRtcNet.Api/Media/MediaStream.cs` | Media Capture | <https://www.w3.org/TR/mediacapture-streams/#mediastream> | seeded |
+| `MediaStreamTrack` | `WebRtcNet.Api/Media/MediaStreamTrack.cs` | Media Capture | <https://www.w3.org/TR/mediacapture-streams/#dom-mediastreamtrack-applyconstraints> | seeded |
 | `MediaTrackConstraints` | `WebRtcNet.Api/Media/MediaTrackConstraints.cs` | Media Capture | <https://www.w3.org/TR/mediacapture-streams/#dom-mediatrackconstraints> | seeded |
 | `MediaTrackCapabilities` | `WebRtcNet.Api/Media/MediaTrackCapabilities.cs` | Media Capture | <https://www.w3.org/TR/mediacapture-streams/#dom-mediatrackcapabilities> | seeded |
 | `MediaTrackSettings` | `WebRtcNet.Api/Media/MediaTrackSettings.cs` | Media Capture | <https://www.w3.org/TR/mediacapture-streams/#dom-mediatracksettings> | seeded |
 | `MediaStreamConstraints` | `WebRtcNet.Api/Media/MediaStreamConstraints.cs` | Media Capture | <https://www.w3.org/TR/mediacapture-streams/#dom-mediastreamconstraints> | seeded |
-| `IRtcStatsReport` | `WebRtcNet.Api/IRtcStatsReport.cs` | WebRTC Stats | <https://www.w3.org/TR/webrtc-stats/#rtcstatsreport-object> | seeded |
+| `RtcStats` | `WebRtcNet.Api/RtcStatsReport.cs` | WebRTC Stats | <https://www.w3.org/TR/webrtc-stats/#rtcstatsreport-object> | seeded |
 | `RtcStatsReport` | `WebRtcNet.Api/RtcStatsReport.cs` | WebRTC Stats | <https://www.w3.org/TR/webrtc-stats/#dom-rtcstatsreport> | seeded |


### PR DESCRIPTION
## Summary
- remove non-spec volume and dtx additions
- remove non-spec DTMF members and add validated DTMF spec links
- align RTP stats string defaults and update RTP stats contract tests
- make ValueRange<T> min/max nullable and simplify RangeConstraint<T> accordingly
- keep other contract/doc corrections from issue #34 review and update spec-map entries

## Validation
- dotnet build WebRtcNet.Api/WebRtcNet.Api.csproj -c Debug
- dotnet test WebRtcNet.Api.UnitTests/WebRtcNet.Api.UnitTests.csproj

Closes #34