### PR TITLE
Fix interop/API type mismatches: RtcDataChannel width, SetLocalDescription spec alignment

### DIFF
--- a/WebRtcInterop/Marshaling/MarshalPeerConnection.h
+++ b/WebRtcInterop/Marshaling/MarshalPeerConnection.h
@@ -168,8 +168,4 @@ namespace msclr::interop
 
 		return WebRtcNet::RtcSessionDescription(from_type, sdp);
 	}
-
-	// TODO: Add marshal_as<webrtc::SessionDescriptionInterface*>(RtcLocalSessionDescriptionInit) for
-	// SetLocalDescription. A null Type maps to the implicit-type native path — call the no-arg
-	// SetLocalDescription() overload on the native PeerConnection in that case.
 }

--- a/WebRtcInterop/Marshaling/MarshalPeerConnection.h
+++ b/WebRtcInterop/Marshaling/MarshalPeerConnection.h
@@ -168,4 +168,8 @@ namespace msclr::interop
 
 		return WebRtcNet::RtcSessionDescription(from_type, sdp);
 	}
+
+	// TODO: Add marshal_as<webrtc::SessionDescriptionInterface*>(RtcLocalSessionDescriptionInit) for
+	// SetLocalDescription. A null Type maps to the implicit-type native path — call the no-arg
+	// SetLocalDescription() overload on the native PeerConnection in that case.
 }

--- a/WebRtcInterop/RtcDataChannel.cpp
+++ b/WebRtcInterop/RtcDataChannel.cpp
@@ -67,14 +67,14 @@ namespace WebRtcInterop
 		return GetNativeDataChannelInterface(true)->ordered();
 	}
 
-	Nullable<uint32_t> RtcDataChannel::MaxPacketLifeTime::get()
+	Nullable<uint16_t> RtcDataChannel::MaxPacketLifeTime::get()
 	{
-		return marshal_as<uint32_t>(GetNativeDataChannelInterface(true)->maxPacketLifeTime());
+		return marshal_as<uint16_t>(GetNativeDataChannelInterface(true)->maxPacketLifeTime());
 	}
 
-	Nullable<uint32_t> RtcDataChannel::MaxRetransmits::get()
+	Nullable<uint16_t> RtcDataChannel::MaxRetransmits::get()
 	{
-		return marshal_as<uint32_t>(GetNativeDataChannelInterface(true)->maxRetransmitsOpt());
+		return marshal_as<uint16_t>(GetNativeDataChannelInterface(true)->maxRetransmitsOpt());
 	}
 
 	String^ RtcDataChannel::Protocol::get()

--- a/WebRtcInterop/RtcDataChannel.h
+++ b/WebRtcInterop/RtcDataChannel.h
@@ -20,8 +20,8 @@ namespace WebRtcInterop
 		// Inherited via RtcDataChannel
 		virtual property String^ Label { String^ get() override; }
 		virtual property bool Ordered { bool get() override; }
-		virtual property Nullable<uint32_t> MaxPacketLifeTime { Nullable<uint32_t> get() override; }
-		virtual property Nullable<uint32_t> MaxRetransmits { Nullable<uint32_t> get() override; }
+		virtual property Nullable<uint16_t> MaxPacketLifeTime { Nullable<uint16_t> get() override; }
+		virtual property Nullable<uint16_t> MaxRetransmits { Nullable<uint16_t> get() override; }
 		virtual property String^ Protocol { String^ get() override; }
 		virtual property bool Negotiated { bool get() override; }
 		virtual property Nullable<uint16_t> Id { Nullable<uint16_t> get() override; }

--- a/WebRtcInterop/RtcPeerConnection.cpp
+++ b/WebRtcInterop/RtcPeerConnection.cpp
@@ -104,7 +104,7 @@ namespace WebRtcInterop
 		return task;
 	}
 
-	Task^ RtcPeerConnection::SetLocalDescription(RtcSessionDescription description)
+	Task^ RtcPeerConnection::SetLocalDescription(Nullable<RtcLocalSessionDescriptionInit> description)
 	{
 		throw gcnew NotImplementedException();
 		// TODO: insert return statement here

--- a/WebRtcInterop/RtcPeerConnection.cpp
+++ b/WebRtcInterop/RtcPeerConnection.cpp
@@ -106,8 +106,14 @@ namespace WebRtcInterop
 
 	Task^ RtcPeerConnection::SetLocalDescription(Nullable<RtcLocalSessionDescriptionInit> description)
 	{
+		// TODO: Implement using two native overloads on PeerConnectionInterface:
+		//   - description is null, or description.Value.Type is null:
+		//       -> SetLocalDescription(observer)  [native creates offer/answer from signaling state]
+		//   - description.Value.Type has a value:
+		//       -> SetLocalDescription(unique_ptr<SessionDescriptionInterface>, observer)
+		// Add marshal_as<webrtc::SessionDescriptionInterface*>(RtcLocalSessionDescriptionInit) in
+		// MarshalPeerConnection.h to support the second path.
 		throw gcnew NotImplementedException();
-		// TODO: insert return statement here
 	}
 
 	Task^ RtcPeerConnection::SetRemoteDescription(RtcSessionDescription description)

--- a/WebRtcInterop/RtcPeerConnection.h
+++ b/WebRtcInterop/RtcPeerConnection.h
@@ -91,7 +91,7 @@ namespace WebRtcInterop
 		virtual Task^ AddIceCandidate(RtcIceCandidate^ candidate) override;
 		virtual void RestartIce() override;
 
-		virtual Task^ SetLocalDescription(RtcSessionDescription description) override;
+		virtual Task^ SetLocalDescription(Nullable<RtcLocalSessionDescriptionInit> description) override;
 		virtual Task^ SetRemoteDescription(RtcSessionDescription description) override;
 
 		virtual RtcRtpSender^ AddTrack(WebRtcNet::Media::MediaStreamTrack^ track,

--- a/WebRtcNet.Api.UnitTests/RtcPeerConnectionContractTests.cs
+++ b/WebRtcNet.Api.UnitTests/RtcPeerConnectionContractTests.cs
@@ -79,14 +79,20 @@ public class RtcPeerConnectionContractTests
 	{
 		var setLocalDescription = typeof(RtcPeerConnection).GetMethod(
 			nameof(RtcPeerConnection.SetLocalDescription),
-			new[] { typeof(RtcSessionDescription?) });
+			new[] { typeof(RtcLocalSessionDescriptionInit?) });
 		var addIceCandidate = typeof(RtcPeerConnection).GetMethod(
 			nameof(RtcPeerConnection.AddIceCandidate),
 			new[] { typeof(RtcIceCandidate) });
 
-		Assert.That(setLocalDescription, Is.Not.Null);
+		Assert.That(setLocalDescription, Is.Not.Null,
+			"SetLocalDescription must accept RtcLocalSessionDescriptionInit? (spec: RTCLocalSessionDescriptionInit, type optional)");
 		Assert.That(setLocalDescription!.GetParameters()[0].IsOptional, Is.True);
 		Assert.That(setLocalDescription.GetParameters()[0].DefaultValue, Is.Null);
+
+		// Verify the parameter is NOT the old RtcSessionDescription? type — type distinction is spec-required.
+		Assert.That(setLocalDescription.GetParameters()[0].ParameterType,
+			Is.Not.EqualTo(typeof(RtcSessionDescription?)),
+			"SetLocalDescription must use RtcLocalSessionDescriptionInit (RTCLocalSessionDescriptionInit), not RtcSessionDescription (RTCSessionDescriptionInit)");
 
 		Assert.That(addIceCandidate, Is.Not.Null);
 		Assert.That(addIceCandidate!.GetParameters()[0].IsOptional, Is.True);

--- a/WebRtcNet.Api/RtcPeerConnection.cs
+++ b/WebRtcNet.Api/RtcPeerConnection.cs
@@ -334,15 +334,16 @@ public abstract class RtcPeerConnection
 
 	/// <summary>
 	/// The SetLocalDescription() method instructs the RtcPeerConnection to apply the supplied
-	/// <see cref="RtcSessionDescription">RtcSessionDescription</see> as the
+	/// <see cref="RtcLocalSessionDescriptionInit">description</see> as the
 	/// <see cref="LocalDescription">local description</see>.
 	/// </summary>
 	/// <param name="description">
-	/// A session description containing the SDP describing the local session, or null to let the implementation
-	/// infer and apply the next local description.
+	/// A local session description init whose <c>type</c> may be omitted to let the implementation
+	/// infer it from the current signaling state, or <see langword="null"/> to use the implementation's
+	/// default (equivalent to passing an empty <c>RTCLocalSessionDescriptionInit</c>).
 	/// </param>
 	/// <seealso href="https://www.w3.org/TR/webrtc/#dom-peerconnection-setlocaldescription" />
-	public abstract Task SetLocalDescription(RtcSessionDescription? description = null);
+	public abstract Task SetLocalDescription(RtcLocalSessionDescriptionInit? description = null);
 
 	/// <summary>
 	/// The SetRemoteDescription() method instructs the RTCPeerConnection to apply the supplied

--- a/WebRtcNet.Api/RtcSessionDescription.cs
+++ b/WebRtcNet.Api/RtcSessionDescription.cs
@@ -1,3 +1,5 @@
+using System;
+
 namespace WebRtcNet;
 
 /// <summary>
@@ -36,8 +38,8 @@ public enum RtcSdpType
 /// <see cref="RtcPeerConnection.CreateAnswer"/>, or received from a remote peer via signaling.
 /// Models <c>RTCSessionDescriptionInit</c> where <c>type</c> is required.
 /// </summary>
-/// <seealso href="https://www.w3.org/TR/webrtc/#dom-rtcsessiondescriptioninit" />
-public struct RtcSessionDescription
+/// <seealso href="https://www.w3.org/TR/webrtc/#rtcsessiondescription-class" />
+public record struct RtcSessionDescription
 {
 	/// <summary>
 	/// Initializes a session description with a type and SDP payload.
@@ -53,12 +55,27 @@ public struct RtcSessionDescription
 	/// <summary>
 	/// Gets the SDP description type.
 	/// </summary>
-	public readonly RtcSdpType Type;
+	/// <seealso href="https://www.w3.org/TR/webrtc/#dom-rtcsessiondescriptioninit-type" />
+	public RtcSdpType Type { get; init; }
 
 	/// <summary>
 	/// Gets the SDP payload string.
 	/// </summary>
-	public readonly string Sdp;
+	/// <seealso href="https://www.w3.org/TR/webrtc/#dom-rtcsessiondescriptioninit-sdp" />
+	public string Sdp { get; init; }
+
+	/// <summary>
+	/// Implicitly converts an <see cref="RtcLocalSessionDescriptionInit"/> to an
+	/// <see cref="RtcSessionDescription"/>. Throws if <see cref="RtcLocalSessionDescriptionInit.Type"/>
+	/// is <see langword="null"/>, as <see cref="Type"/> is required.
+	/// </summary>
+	/// <exception cref="InvalidOperationException">
+	/// Thrown when <see cref="RtcLocalSessionDescriptionInit.Type"/> is <see langword="null"/>.
+	/// </exception>
+	public static implicit operator RtcSessionDescription(RtcLocalSessionDescriptionInit description) =>
+		new(description.Type ?? throw new InvalidOperationException(
+				"Cannot convert RtcLocalSessionDescriptionInit to RtcSessionDescription: Type is null."),
+			description.Sdp);
 }
 
 /// <summary>
@@ -72,7 +89,7 @@ public struct RtcSessionDescription
 /// can be passed directly to <see cref="RtcPeerConnection.SetLocalDescription"/> without a cast.
 /// </remarks>
 /// <seealso href="https://www.w3.org/TR/webrtc/#dom-rtclocalsessiondescriptioninit" />
-public struct RtcLocalSessionDescriptionInit
+public record struct RtcLocalSessionDescriptionInit
 {
 	/// <summary>
 	/// Initializes a local session description init with an optional type and SDP payload.
@@ -91,12 +108,14 @@ public struct RtcLocalSessionDescriptionInit
 	/// <summary>
 	/// Gets the SDP description type, or <see langword="null"/> if the implementation should infer it.
 	/// </summary>
-	public readonly RtcSdpType? Type;
+	/// <seealso href="https://www.w3.org/TR/webrtc/#dom-rtclocalsessiondescriptioninit-type" />
+	public RtcSdpType? Type { get; init; }
 
 	/// <summary>
 	/// Gets the SDP payload string.
 	/// </summary>
-	public readonly string Sdp;
+	/// <seealso href="https://www.w3.org/TR/webrtc/#dom-rtclocalsessiondescriptioninit-sdp" />
+	public string Sdp { get; init; } = string.Empty;
 
 	/// <summary>
 	/// Implicitly converts an <see cref="RtcSessionDescription"/> (required type) to an

--- a/WebRtcNet.Api/RtcSessionDescription.cs
+++ b/WebRtcNet.Api/RtcSessionDescription.cs
@@ -62,7 +62,7 @@ public record struct RtcSessionDescription
 	/// Gets the SDP payload string.
 	/// </summary>
 	/// <seealso href="https://www.w3.org/TR/webrtc/#dom-rtcsessiondescriptioninit-sdp" />
-	public string Sdp { get; init; }
+	public string Sdp { get; init; } = string.Empty;
 
 	/// <summary>
 	/// Implicitly converts an <see cref="RtcLocalSessionDescriptionInit"/> to an

--- a/WebRtcNet.Api/RtcSessionDescription.cs
+++ b/WebRtcNet.Api/RtcSessionDescription.cs
@@ -32,7 +32,9 @@ public enum RtcSdpType
 }
 
 /// <summary>
-/// Represents an SDP session description used by <see cref="RtcPeerConnection" /> operations.
+/// Represents an SDP session description produced by <see cref="RtcPeerConnection.CreateOffer"/> or
+/// <see cref="RtcPeerConnection.CreateAnswer"/>, or received from a remote peer via signaling.
+/// Models <c>RTCSessionDescriptionInit</c> where <c>type</c> is required.
 /// </summary>
 /// <seealso href="https://www.w3.org/TR/webrtc/#dom-rtcsessiondescriptioninit" />
 public struct RtcSessionDescription
@@ -57,4 +59,49 @@ public struct RtcSessionDescription
 	/// Gets the SDP payload string.
 	/// </summary>
 	public readonly string Sdp;
+}
+
+/// <summary>
+/// The description passed to <see cref="RtcPeerConnection.SetLocalDescription"/>.
+/// Models <c>RTCLocalSessionDescriptionInit</c> where <c>type</c> is optional — the implementation
+/// may infer the type when it is omitted.
+/// </summary>
+/// <remarks>
+/// Implicitly converts from <see cref="RtcSessionDescription"/> so that the value returned by
+/// <see cref="RtcPeerConnection.CreateOffer"/> or <see cref="RtcPeerConnection.CreateAnswer"/>
+/// can be passed directly to <see cref="RtcPeerConnection.SetLocalDescription"/> without a cast.
+/// </remarks>
+/// <seealso href="https://www.w3.org/TR/webrtc/#dom-rtclocalsessiondescriptioninit" />
+public struct RtcLocalSessionDescriptionInit
+{
+	/// <summary>
+	/// Initializes a local session description init with an optional type and SDP payload.
+	/// </summary>
+	/// <param name="type">
+	/// The SDP description type, or <see langword="null"/> to let the implementation infer the type
+	/// from the current signaling state.
+	/// </param>
+	/// <param name="sdp">The SDP payload text. Defaults to empty string.</param>
+	public RtcLocalSessionDescriptionInit(RtcSdpType? type = null, string sdp = "")
+	{
+		Type = type;
+		Sdp = sdp;
+	}
+
+	/// <summary>
+	/// Gets the SDP description type, or <see langword="null"/> if the implementation should infer it.
+	/// </summary>
+	public readonly RtcSdpType? Type;
+
+	/// <summary>
+	/// Gets the SDP payload string.
+	/// </summary>
+	public readonly string Sdp;
+
+	/// <summary>
+	/// Implicitly converts an <see cref="RtcSessionDescription"/> (required type) to an
+	/// <see cref="RtcLocalSessionDescriptionInit"/> (optional type).
+	/// </summary>
+	public static implicit operator RtcLocalSessionDescriptionInit(RtcSessionDescription description) =>
+		new(description.Type, description.Sdp);
 }


### PR DESCRIPTION
Fixes #37

## Changes

### RtcDataChannel (uint32_t -> uint16_t)
MaxPacketLifeTime and MaxRetransmits were declared as Nullable<uint32_t> in the C++/CLI layer. The W3C spec defines both as unsigned short, matching the C# abstract ushort? (Nullable<uint16_t>). The mismatch prevented the interop overrides from satisfying their abstract VTable slots.

### SetLocalDescription spec alignment + VTable fix
The C++/CLI override used RtcSessionDescription (non-nullable value type), which is a different CLR signature from the abstract Nullable<RtcSessionDescription>. Beyond the VTable bug, the W3C spec uses two distinct dictionary types:

- setLocalDescription takes RTCLocalSessionDescriptionInit where type is optional
- setRemoteDescription takes RTCSessionDescriptionInit where type is required

The optional type is meaningful: it selects between two native overloads on PeerConnectionInterface -- one that takes an explicit SessionDescriptionInterface, and one that lets the native stack create the description itself.

This PR introduces RtcLocalSessionDescriptionInit with RtcSdpType? Type, an implicit conversion from RtcSessionDescription (so CreateOffer/CreateAnswer results pass through without a cast), and updates the abstract signature, C++/CLI override, and contract test accordingly.