### PR TITLE
Add BasicVideoChat WPF example application

### DIFF
--- a/CONTEXT.md
+++ b/CONTEXT.md
@@ -1,0 +1,34 @@
+# WebRtcNet Domain Glossary
+
+This file is a glossary of canonical terms used in the WebRtcNet codebase.
+It contains **no implementation details** — only term definitions.
+
+---
+
+## Terms
+
+### Host
+A peer that initiates a WebRTC session by opening a TCP listener and waiting for
+an incoming connection before creating an SDP offer.
+
+### Guest
+A peer that joins a WebRTC session by dialling the Host's IP address and port,
+then responding to the Host's SDP offer with an SDP answer.
+
+### Signaling
+The out-of-band exchange of SDP offers/answers and ICE candidates between two
+peers. In this repository the term refers specifically to message exchange; it
+does not imply a server. BasicVideoChat uses direct TCP signaling.
+
+### SignalingMessage
+A newline-delimited JSON envelope carrying one of: `Offer`, `Answer`,
+`Candidate`, or `Bye`.
+
+### BasicVideoChat
+The first example application. Demonstrates a peer-to-peer audio/video call over
+a direct TCP signaling channel, targeting both .NET 10 and .NET Framework 4.8.
+
+### WpfVideoRenderer
+A prototype `VideoRenderer` implementation backed by a WPF `WriteableBitmap`.
+Lives in `examples/BasicVideoChat` until a proper `WebRtcNet.Wpf` renderer
+assembly is created (see issue #36).

--- a/WebRtcNet.slnx
+++ b/WebRtcNet.slnx
@@ -25,6 +25,9 @@
   <Folder Name="/third_party/">
     <Project Path="third-party/shared-items/googletest/googletest.vcxitems" Id="357b6b66-ab73-41cd-9271-1b4e5c41dde1" />
   </Folder>
+  <Folder Name="/Examples/">
+    <Project Path="examples/BasicVideoChat/BasicVideoChat.csproj" Id="ce07d5b9-b81d-4834-a99b-6917ae0b5982" />
+  </Folder>
   <Project Path="WebRtcNet.Api.UnitTests/WebRtcNet.Api.UnitTests.csproj" />
   <Project Path="WebRtcNet.Api/WebRtcNet.Api.csproj" />
   <Project Path="WebRtcNet/WebRtcNet.csproj" />

--- a/examples/BasicVideoChat/App.xaml
+++ b/examples/BasicVideoChat/App.xaml
@@ -1,0 +1,7 @@
+<Application x:Class="BasicVideoChat.App"
+             xmlns="http://schemas.microsoft.com/winfx/2006/xaml/presentation"
+             xmlns:x="http://schemas.microsoft.com/winfx/2006/xaml"
+             StartupUri="MainWindow.xaml">
+	<Application.Resources>
+	</Application.Resources>
+</Application>

--- a/examples/BasicVideoChat/App.xaml.cs
+++ b/examples/BasicVideoChat/App.xaml.cs
@@ -1,0 +1,7 @@
+using System.Windows;
+
+namespace BasicVideoChat;
+
+public partial class App : Application
+{
+}

--- a/examples/BasicVideoChat/BasicVideoChat.csproj
+++ b/examples/BasicVideoChat/BasicVideoChat.csproj
@@ -1,0 +1,22 @@
+<Project Sdk="Microsoft.NET.Sdk">
+	<PropertyGroup>
+		<OutputType>WinExe</OutputType>
+		<TargetFrameworks>net10.0-windows;net48</TargetFrameworks>
+		<UseWPF>true</UseWPF>
+		<Configurations>Debug;Release</Configurations>
+		<Platforms>x64;x86;ARM64</Platforms>
+		<LangVersion>latest</LangVersion>
+		<Nullable>enable</Nullable>
+		<AssemblyTitle>BasicVideoChat</AssemblyTitle>
+		<AssemblyDescription>A basic WebRTC peer-to-peer video chat example using WebRtcNet</AssemblyDescription>
+	</PropertyGroup>
+
+	<ItemGroup>
+		<ProjectReference Include="..\..\WebRtcNet\WebRtcNet.csproj" />
+	</ItemGroup>
+
+	<!-- System.Text.Json is inbox on net10.0; add the NuGet package for net48 only. -->
+	<ItemGroup Condition="'$(TargetFramework)' == 'net48'">
+		<PackageReference Include="System.Text.Json" Version="9.0.5" />
+	</ItemGroup>
+</Project>

--- a/examples/BasicVideoChat/MainWindow.xaml
+++ b/examples/BasicVideoChat/MainWindow.xaml
@@ -1,0 +1,68 @@
+<Window x:Class="BasicVideoChat.MainWindow"
+        xmlns="http://schemas.microsoft.com/winfx/2006/xaml/presentation"
+        xmlns:x="http://schemas.microsoft.com/winfx/2006/xaml"
+        Title="BasicVideoChat" Height="600" Width="900" MinWidth="640" MinHeight="420">
+	<Grid>
+		<Grid.RowDefinitions>
+			<RowDefinition Height="Auto"/>
+			<RowDefinition Height="*"/>
+			<RowDefinition Height="Auto"/>
+		</Grid.RowDefinitions>
+
+		<!-- Connection controls -->
+		<WrapPanel Grid.Row="0" Margin="8,6" Orientation="Horizontal">
+			<RadioButton x:Name="HostRadio" Content="Host" GroupName="Mode"
+			             IsChecked="True" VerticalAlignment="Center" Margin="0,0,8,0"
+			             Checked="HostRadio_Checked"/>
+			<RadioButton x:Name="GuestRadio" Content="Guest" GroupName="Mode"
+			             VerticalAlignment="Center" Margin="0,0,14,0"
+			             Checked="GuestRadio_Checked"/>
+			<TextBlock Text="IP:" VerticalAlignment="Center" Margin="0,0,4,0"/>
+			<TextBox x:Name="IpBox" Width="130" Text="127.0.0.1" IsEnabled="False"
+			         VerticalAlignment="Center" Margin="0,0,8,0"/>
+			<TextBlock Text="Port:" VerticalAlignment="Center" Margin="0,0,4,0"/>
+			<TextBox x:Name="PortBox" Width="55" Text="7777"
+			         VerticalAlignment="Center" Margin="0,0,14,0"/>
+			<Button x:Name="ConnectBtn" Content="Connect" Width="80"
+			        Margin="0,0,6,0" Click="ConnectBtn_Click"/>
+			<Button x:Name="HangUpBtn" Content="Hang Up" Width="80"
+			        Margin="0,0,14,0" IsEnabled="False" Click="HangUpBtn_Click"/>
+			<TextBlock Text="Status: " VerticalAlignment="Center"/>
+			<TextBlock x:Name="StatusText" Text="Ready" VerticalAlignment="Center"
+			           FontWeight="SemiBold"/>
+		</WrapPanel>
+
+		<!-- Video panels -->
+		<Grid Grid.Row="1">
+			<Grid.ColumnDefinitions>
+				<ColumnDefinition Width="*"/>
+				<ColumnDefinition Width="*"/>
+			</Grid.ColumnDefinitions>
+
+			<Border Grid.Column="0" Background="#FF1A1A1A" Margin="4,2,2,2">
+				<Grid>
+					<Image x:Name="LocalVideo" Stretch="Uniform"/>
+					<TextBlock Text="Local" Foreground="White" Opacity="0.5"
+					           HorizontalAlignment="Left" VerticalAlignment="Bottom" Margin="6"/>
+				</Grid>
+			</Border>
+
+			<Border Grid.Column="1" Background="#FF1A1A1A" Margin="2,2,4,2">
+				<Grid>
+					<Image x:Name="RemoteVideo" Stretch="Uniform"/>
+					<TextBlock Text="Remote" Foreground="White" Opacity="0.5"
+					           HorizontalAlignment="Left" VerticalAlignment="Bottom" Margin="6"/>
+				</Grid>
+			</Border>
+		</Grid>
+
+		<!-- Media toggle controls -->
+		<StackPanel Grid.Row="2" Orientation="Horizontal" Margin="8,6"
+		            HorizontalAlignment="Center">
+			<ToggleButton x:Name="MuteBtn" Content="Mute Audio" Width="100"
+			              Margin="0,0,8,0" IsEnabled="False" Click="MuteBtn_Click"/>
+			<ToggleButton x:Name="CameraBtn" Content="Camera Off" Width="100"
+			              IsEnabled="False" Click="CameraBtn_Click"/>
+		</StackPanel>
+	</Grid>
+</Window>

--- a/examples/BasicVideoChat/MainWindow.xaml.cs
+++ b/examples/BasicVideoChat/MainWindow.xaml.cs
@@ -1,0 +1,226 @@
+using System;
+using System.Linq;
+using System.Threading.Tasks;
+using System.Windows;
+using BasicVideoChat.Signaling;
+using WebRtcNet;
+using WebRtcNet.Media;
+
+namespace BasicVideoChat;
+
+public partial class MainWindow : Window
+{
+	private const int DefaultPort = 7777;
+
+	// Default STUN server for NAT traversal. Works for both LAN and internet connections.
+	// For LAN-only use you can pass an empty RtcConfiguration().
+	// Replace with your own STUN/TURN server if needed.
+	// See: https://webrtc.org/getting-started/turn-server
+	private static readonly RtcConfiguration DefaultConfiguration = new(
+		new[] { new RtcIceServer("stun:stun.l.google.com:19302") });
+
+	private WebRtcInterop.RtcPeerConnection? _peerConnection;
+	private TcpSignalingChannel? _signaling;
+	private MediaStream? _localStream;
+	private MediaStreamTrack? _audioTrack;
+	private MediaStreamTrack? _videoTrack;
+	private WpfVideoRenderer? _localRenderer;
+	private WpfVideoRenderer? _remoteRenderer;
+
+	public MainWindow()
+	{
+		InitializeComponent();
+	}
+
+	private bool IsHost => HostRadio.IsChecked == true;
+
+	private void HostRadio_Checked(object sender, RoutedEventArgs e) =>
+		IpBox.IsEnabled = false;
+
+	private void GuestRadio_Checked(object sender, RoutedEventArgs e) =>
+		IpBox.IsEnabled = true;
+
+	private async void ConnectBtn_Click(object sender, RoutedEventArgs e)
+	{
+		ConnectBtn.IsEnabled = false;
+		try
+		{
+			await StartCallAsync();
+			HangUpBtn.IsEnabled = true;
+			MuteBtn.IsEnabled = true;
+			CameraBtn.IsEnabled = true;
+		}
+		catch (Exception ex)
+		{
+			SetStatus($"Error: {ex.Message}");
+			ConnectBtn.IsEnabled = true;
+		}
+	}
+
+	private async void HangUpBtn_Click(object sender, RoutedEventArgs e) =>
+		await HangUpAsync();
+
+	private void MuteBtn_Click(object sender, RoutedEventArgs e)
+	{
+		if (_audioTrack != null)
+			_audioTrack.Enabled = MuteBtn.IsChecked != true;
+	}
+
+	private void CameraBtn_Click(object sender, RoutedEventArgs e)
+	{
+		if (_videoTrack != null)
+			_videoTrack.Enabled = CameraBtn.IsChecked != true;
+	}
+
+	private async Task StartCallAsync()
+	{
+		SetStatus("Acquiring media...");
+
+		var mediaDevices = new WebRtcInterop.Media.MediaDevices();
+		_localStream = await mediaDevices.GetUserMedia(new MediaStreamConstraints(true, true));
+
+		_audioTrack = _localStream.GetAudioTracks().FirstOrDefault();
+		_videoTrack = _localStream.GetVideoTracks().FirstOrDefault();
+
+		_localRenderer = new WpfVideoRenderer(LocalVideo);
+		_remoteRenderer = new WpfVideoRenderer(RemoteVideo);
+		// TODO: Attach _localRenderer to _videoTrack once VideoRenderer interface is expanded.
+
+		// NOTE: Many WebRtcInterop methods currently throw NotImplementedException — this example
+		// will not run end-to-end until they are implemented.  SetLocalDescription and
+		// AddIceCandidate are the minimum required for a basic call flow.
+		_peerConnection = new WebRtcInterop.RtcPeerConnection(DefaultConfiguration);
+		_peerConnection.OnIceCandidate += OnIceCandidate;
+		_peerConnection.OnTrack += OnTrack;
+		_peerConnection.OnConnectionStateChange += OnConnectionStateChange;
+
+		foreach (var track in _localStream.GetTracks())
+			_peerConnection.AddTrack(track, _localStream);
+
+		_signaling = new TcpSignalingChannel();
+		_signaling.MessageHandler = OnSignalingMessageAsync;
+		_signaling.Disconnected += () => Dispatcher.BeginInvoke(async () => await HangUpAsync());
+
+		if (IsHost)
+		{
+			var port = int.TryParse(PortBox.Text, out var p) ? p : DefaultPort;
+			SetStatus($"Listening on port {port}...");
+			await _signaling.ListenAsync(port);
+			SetStatus("Guest connected. Creating offer...");
+
+			// Drive the offer explicitly here rather than relying on OnNegotiationNeeded,
+			// since we control when the signaling channel is ready.
+			var offer = await _peerConnection.CreateOffer();
+			await _peerConnection.SetLocalDescription(offer);
+			await _signaling.SendAsync(new SignalingMessage { Type = SignalingMessageType.Offer, Sdp = offer.Sdp });
+			SetStatus("Offer sent. Waiting for answer...");
+		}
+		else
+		{
+			var host = IpBox.Text.Trim();
+			var port = int.TryParse(PortBox.Text, out var p) ? p : DefaultPort;
+			SetStatus($"Connecting to {host}:{port}...");
+			await _signaling.ConnectAsync(host, port);
+			SetStatus("Connected. Waiting for offer...");
+		}
+	}
+
+	// MessageHandler is awaited by TcpSignalingChannel before the next message is dispatched,
+	// ensuring that SetRemoteDescription always completes before any AddIceCandidate call.
+	private async Task OnSignalingMessageAsync(SignalingMessage message)
+	{
+		try
+		{
+			switch (message.Type)
+			{
+				case SignalingMessageType.Offer:
+					await _peerConnection!.SetRemoteDescription(
+						new RtcSessionDescription(RtcSdpType.Offer, message.Sdp!));
+					var answer = await _peerConnection.CreateAnswer();
+					await _peerConnection.SetLocalDescription(answer);
+					await _signaling!.SendAsync(new SignalingMessage
+					{
+						Type = SignalingMessageType.Answer,
+						Sdp = answer.Sdp
+					});
+					SetStatus("Answer sent.");
+					break;
+
+				case SignalingMessageType.Answer:
+					await _peerConnection!.SetRemoteDescription(
+						new RtcSessionDescription(RtcSdpType.Answer, message.Sdp!));
+					SetStatus("Answer received.");
+					break;
+
+				case SignalingMessageType.Candidate:
+					await _peerConnection!.AddIceCandidate(new RtcIceCandidate(
+						message.Candidate!, message.SdpMid, message.SdpMLineIndex));
+					break;
+
+				case SignalingMessageType.Bye:
+					Dispatcher.BeginInvoke(async () => await HangUpAsync());
+					break;
+			}
+		}
+		catch (Exception ex)
+		{
+			SetStatus($"Signaling error: {ex.Message}");
+		}
+	}
+
+	private void OnIceCandidate(object? sender, RtcIceCandidateEventArgs e)
+	{
+		// Capture _signaling before the fire-and-forget to guard against a concurrent HangUp.
+		var sig = _signaling;
+		if (sig != null)
+			_ = sig.SendAsync(new SignalingMessage
+			{
+				Type = SignalingMessageType.Candidate,
+				Candidate = e.Candidate.Candidate,
+				SdpMid = e.Candidate.SdpMid,
+				SdpMLineIndex = e.Candidate.SdpMLineIndex
+			});
+	}
+
+	private void OnTrack(object? sender, RtcTrackEventArgs e)
+	{
+		// TODO: Attach e.Track to _remoteRenderer once VideoRenderer interface is expanded.
+		Dispatcher.Invoke(() => SetStatus($"Remote {e.Track.Kind} track received."));
+	}
+
+	private void OnConnectionStateChange(object? sender, EventArgs e) =>
+		Dispatcher.Invoke(() => SetStatus($"Connection: {_peerConnection?.ConnectionState}"));
+
+	private async Task HangUpAsync()
+	{
+		// Best-effort Bye — send before tearing down the channel.
+		if (_signaling != null)
+		{
+			try { await _signaling.SendAsync(new SignalingMessage { Type = SignalingMessageType.Bye }); }
+			catch { }
+			_signaling.Dispose();
+			_signaling = null;
+		}
+
+		_peerConnection?.Close();
+		_peerConnection = null;
+
+		_audioTrack?.Stop();
+		_videoTrack?.Stop();
+		_localStream?.Dispose();
+		_localStream = null;
+		_audioTrack = null;
+		_videoTrack = null;
+
+		ConnectBtn.IsEnabled = true;
+		HangUpBtn.IsEnabled = false;
+		MuteBtn.IsEnabled = false;
+		MuteBtn.IsChecked = false;
+		CameraBtn.IsEnabled = false;
+		CameraBtn.IsChecked = false;
+		SetStatus("Ready");
+	}
+
+	private void SetStatus(string message) =>
+		Dispatcher.Invoke(() => StatusText.Text = message);
+}

--- a/examples/BasicVideoChat/README.md
+++ b/examples/BasicVideoChat/README.md
@@ -1,0 +1,81 @@
+# BasicVideoChat
+
+A peer-to-peer audio/video call example using the **WebRtcNet** API.
+
+Two computers connect directly over TCP — no messaging server required. One peer acts
+as the **Host** (listens for an incoming connection) and the other is the **Guest**
+(dials by IP and port).
+
+---
+
+## Prerequisites
+
+- Windows 10 or later
+- .NET 10.0 **or** .NET Framework 4.8
+- A built copy of `WebRtcInterop` (requires WebRTC native libraries — see the
+  [repository README](../../README.md) for setup)
+
+> **Note:** Because several `WebRtcInterop` methods are not yet implemented,
+> this application will not run end-to-end today. It is intended as a working
+> specification of the API surface that still needs to be wired up in the
+> interop layer.
+
+---
+
+## How to run
+
+### Host side
+
+1. Launch the application.
+2. Leave the **Host** radio button selected.
+3. Set the **Port** (default: `7777`).
+4. Click **Connect** — the app waits for a guest.
+
+### Guest side
+
+1. Launch the application on a second machine.
+2. Select the **Guest** radio button.
+3. Enter the **IP address** of the Host and match the **Port**.
+4. Click **Connect**.
+
+---
+
+## ICE / STUN configuration
+
+The application uses Google's public STUN server by default:
+
+```
+stun:stun.l.google.com:19302
+```
+
+This is hardcoded in `MainWindow.xaml.cs` as `DefaultConfiguration`. For LAN-only
+use you can replace it with an empty `RtcConfiguration()`. For calls across NAT you
+may want to add a TURN server. See the
+[WebRTC getting-started guide](https://webrtc.org/getting-started/turn-server) for
+details on running your own TURN server.
+
+---
+
+## Features
+
+| Feature | Status |
+|---|---|
+| Audio + Video | Pending interop |
+| Mute audio toggle | Pending interop |
+| Camera off toggle | Pending interop |
+| Direct TCP signaling (no server) | Implemented |
+| ICE/STUN support | Implemented |
+
+---
+
+## Architecture notes
+
+- **Signaling**: Newline-delimited JSON over a single persistent TCP connection.
+  `TcpSignalingChannel` serialises/deserialises `SignalingMessage` objects
+  (`Offer`, `Answer`, `Candidate`, `Bye`).
+- **ICE candidate ordering**: The signaling read loop awaits the message handler
+  before reading the next message, so `SetRemoteDescription` is always guaranteed
+  to complete before any `AddIceCandidate` arrives.
+- **WpfVideoRenderer**: A prototype `VideoRenderer` implementation using
+  `WriteableBitmap`. Proper renderer assemblies for WPF, Windows Forms, and WinUI
+  are tracked in [issue #36](https://github.com/General-Fault/WebRtcNet/issues/36).

--- a/examples/BasicVideoChat/Signaling/SignalingMessage.cs
+++ b/examples/BasicVideoChat/Signaling/SignalingMessage.cs
@@ -1,0 +1,30 @@
+using System.Text.Json.Serialization;
+
+namespace BasicVideoChat.Signaling;
+
+internal enum SignalingMessageType
+{
+	Offer,
+	Answer,
+	Candidate,
+	Bye
+}
+
+internal class SignalingMessage
+{
+	[JsonPropertyName("type")]
+	[JsonConverter(typeof(JsonStringEnumConverter))]
+	public SignalingMessageType Type { get; set; }
+
+	[JsonPropertyName("sdp")]
+	public string? Sdp { get; set; }
+
+	[JsonPropertyName("candidate")]
+	public string? Candidate { get; set; }
+
+	[JsonPropertyName("sdpMid")]
+	public string? SdpMid { get; set; }
+
+	[JsonPropertyName("sdpMLineIndex")]
+	public ushort? SdpMLineIndex { get; set; }
+}

--- a/examples/BasicVideoChat/Signaling/TcpSignalingChannel.cs
+++ b/examples/BasicVideoChat/Signaling/TcpSignalingChannel.cs
@@ -1,0 +1,126 @@
+using System;
+using System.IO;
+using System.Net;
+using System.Net.Sockets;
+using System.Text;
+using System.Text.Json;
+using System.Threading;
+using System.Threading.Tasks;
+
+namespace BasicVideoChat.Signaling;
+
+/// <summary>
+/// Minimal TCP signaling channel for peer-to-peer connection setup.
+/// </summary>
+/// <remarks>
+/// One peer calls <see cref="ListenAsync"/> (Host) and the other calls
+/// <see cref="ConnectAsync"/> (Guest). Messages are newline-delimited JSON.
+/// <para>
+/// The read loop awaits <see cref="MessageHandler"/> before processing the next message,
+/// ensuring that <c>SetRemoteDescription</c> always completes before any
+/// <c>AddIceCandidate</c> call arrives from the remote peer.
+/// </para>
+/// </remarks>
+internal sealed class TcpSignalingChannel : IDisposable
+{
+	private TcpListener? _listener;
+	private TcpClient? _client;
+	private StreamReader? _reader;
+	private StreamWriter? _writer;
+	private readonly SemaphoreSlim _writeLock = new(1, 1);
+	private CancellationTokenSource _cts = new();
+
+	/// <summary>
+	/// Invoked sequentially for each received message. The read loop awaits this
+	/// delegate before reading the next line.
+	/// </summary>
+	public Func<SignalingMessage, Task>? MessageHandler { get; set; }
+
+	/// <summary>Raised when the remote side closes the connection.</summary>
+	public event Action? Disconnected;
+
+	/// <summary>
+	/// Starts listening on <paramref name="port"/> and waits for a single guest connection.
+	/// Returns once the guest has connected.
+	/// </summary>
+	public async Task ListenAsync(int port)
+	{
+		_listener = new TcpListener(IPAddress.Any, port);
+		_listener.Start();
+		_client = await _listener.AcceptTcpClientAsync();
+		_listener.Stop();
+		AttachStreams();
+		_ = ReadLoopAsync(_cts.Token);
+	}
+
+	/// <summary>
+	/// Connects to a host at <paramref name="host"/>:<paramref name="port"/>.
+	/// </summary>
+	public async Task ConnectAsync(string host, int port)
+	{
+		_client = new TcpClient();
+		await _client.ConnectAsync(host, port);
+		AttachStreams();
+		_ = ReadLoopAsync(_cts.Token);
+	}
+
+	private void AttachStreams()
+	{
+		var stream = _client!.GetStream();
+		_reader = new StreamReader(stream, Encoding.UTF8);
+		_writer = new StreamWriter(stream, Encoding.UTF8) { AutoFlush = true };
+	}
+
+	/// <summary>
+	/// Sends <paramref name="message"/> as a newline-delimited JSON object.
+	/// Uses a write lock so it is safe to call concurrently from ICE callbacks.
+	/// </summary>
+	public async Task SendAsync(SignalingMessage message)
+	{
+		var json = JsonSerializer.Serialize(message);
+		await _writeLock.WaitAsync().ConfigureAwait(false);
+		try
+		{
+			await _writer!.WriteLineAsync(json).ConfigureAwait(false);
+		}
+		finally
+		{
+			_writeLock.Release();
+		}
+	}
+
+	private async Task ReadLoopAsync(CancellationToken ct)
+	{
+		try
+		{
+			while (!ct.IsCancellationRequested)
+			{
+				var line = await _reader!.ReadLineAsync().ConfigureAwait(false);
+				if (line == null)
+					break;
+
+				var message = JsonSerializer.Deserialize<SignalingMessage>(line);
+				if (message != null && MessageHandler != null)
+					await MessageHandler(message).ConfigureAwait(false);
+			}
+		}
+		catch (OperationCanceledException) { }
+		catch (IOException) { }
+		catch (ObjectDisposedException) { }
+		finally
+		{
+			Disconnected?.Invoke();
+		}
+	}
+
+	public void Dispose()
+	{
+		_cts.Cancel();
+		_cts.Dispose();
+		_writer?.Dispose();
+		_reader?.Dispose();
+		_client?.Dispose();
+		_listener?.Stop();
+		_writeLock.Dispose();
+	}
+}

--- a/examples/BasicVideoChat/WpfVideoRenderer.cs
+++ b/examples/BasicVideoChat/WpfVideoRenderer.cs
@@ -1,0 +1,52 @@
+using System.Windows.Controls;
+using System.Windows.Media;
+using System.Windows.Media.Imaging;
+using WebRtcNet.Media;
+
+namespace BasicVideoChat;
+
+/// <summary>
+/// WPF implementation of <see cref="VideoRenderer"/> using a <see cref="WriteableBitmap"/>-backed
+/// <see cref="Image"/> control.
+/// </summary>
+/// <remarks>
+/// <para>
+/// This is a prototype that lives in <c>BasicVideoChat</c> until a dedicated
+/// <c>WebRtcNet.Wpf</c> renderer assembly is created (see GitHub issue #36).
+/// </para>
+/// <para>
+/// Once the <see cref="VideoRenderer"/> interface is expanded to include a frame-delivery
+/// method, frames should be rendered here via the pattern below. The expected frame format
+/// from the native WebRTC stack is I420 (YUV planar); convert to BGR24 before writing pixels.
+/// </para>
+/// <code>
+/// public void RenderFrame(byte[] bgrData, int width, int height)
+/// {
+///     _image.Dispatcher.BeginInvoke(() =>
+///     {
+///         if (_bitmap == null || _bitmap.PixelWidth != width || _bitmap.PixelHeight != height)
+///         {
+///             _bitmap = new WriteableBitmap(width, height, 96, 96, PixelFormats.Bgr24, null);
+///             _image.Source = _bitmap;
+///         }
+///         _bitmap.Lock();
+///         _bitmap.WritePixels(new Int32Rect(0, 0, width, height), bgrData, width * 3, 0);
+///         _bitmap.Unlock();
+///     });
+/// }
+/// </code>
+/// </remarks>
+public class WpfVideoRenderer : VideoRenderer
+{
+	private readonly Image _image;
+#pragma warning disable IDE0052 // field reserved for future use when VideoRenderer is expanded
+	private WriteableBitmap? _bitmap;
+#pragma warning restore IDE0052
+
+	/// <summary>Creates a renderer backed by the given WPF <see cref="Image"/> control.</summary>
+	/// <param name="image">The WPF <see cref="Image"/> control that will display video frames.</param>
+	public WpfVideoRenderer(Image image)
+	{
+		_image = image;
+	}
+}


### PR DESCRIPTION
Closes #39

## What's included

- **xamples/BasicVideoChat/** — WPF app targeting 
et10.0-windows and 
et48, all three platforms (x64/x86/ARM64)
- **Direct TCP signaling** — Host listens, Guest connects by IP. No signaling server needed.
- **Full call flow** — offer/answer/ICE exchange via \TcpSignalingChannel\ with sequential message dispatch (no ICE-before-description race)
- **UI** — side-by-side local/remote video panels, Mute Audio, Camera Off toggles
- **\WpfVideoRenderer\** — prototype placeholder until \WebRtcNet.Wpf\ is created (see #36)
- **\CONTEXT.md\** — domain glossary (Host, Guest, Signaling, etc.)
- **\WebRtcNet.slnx\** — \/Examples/\ solution folder

## Known limitation

Building with \dotnet build\ fails because \WebRtcNet.csproj\ transitively references the C++/CLI \.vcxproj\ projects, which the dotnet CLI cannot process. Use MSBuild (via Visual Studio or the full VS Build Tools) to build this example.

The example is also not end-to-end functional — \WebRtcInterop\ methods are partially unimplemented. Its purpose is to define expected API usage and drive implementation priorities.