### PR TITLE
Normalize project configuration and platform mappings

### DIFF
--- a/WebRtcInterop.UnitTests/WebRtcInterop.UnitTests.vcxproj
+++ b/WebRtcInterop.UnitTests/WebRtcInterop.UnitTests.vcxproj
@@ -1,9 +1,17 @@
 <?xml version="1.0" encoding="utf-8"?>
 <Project DefaultTargets="Build" ToolsVersion="15.0" xmlns="http://schemas.microsoft.com/developer/msbuild/2003">
   <ItemGroup Label="ProjectConfigurations">
+    <ProjectConfiguration Include="Debug|ARM64">
+      <Configuration>Debug</Configuration>
+      <Platform>ARM64</Platform>
+    </ProjectConfiguration>
     <ProjectConfiguration Include="Debug|Win32">
       <Configuration>Debug</Configuration>
       <Platform>Win32</Platform>
+    </ProjectConfiguration>
+    <ProjectConfiguration Include="Release|ARM64">
+      <Configuration>Release</Configuration>
+      <Platform>ARM64</Platform>
     </ProjectConfiguration>
     <ProjectConfiguration Include="Release|Win32">
       <Configuration>Release</Configuration>
@@ -17,23 +25,15 @@
       <Configuration>Release</Configuration>
       <Platform>x64</Platform>
     </ProjectConfiguration>
-    <ProjectConfiguration Include="Debug|ARM64">
-      <Configuration>Debug</Configuration>
-      <Platform>ARM64</Platform>
-    </ProjectConfiguration>
-    <ProjectConfiguration Include="Release|ARM64">
-      <Configuration>Release</Configuration>
-      <Platform>ARM64</Platform>
-    </ProjectConfiguration>
   </ItemGroup>
   <PropertyGroup Label="Globals">
     <ProjectGuid>{5cfb4d3d-2e45-4a55-91ca-e45b7db34bf7}</ProjectGuid>
-    <Keyword>Win32Proj</Keyword>
+    <Keyword>ManagedCProj</Keyword>
     <WindowsTargetPlatformVersion>10.0</WindowsTargetPlatformVersion>
     <ConfigurationType>Application</ConfigurationType>
     <PlatformToolset>v145</PlatformToolset>
     <CharacterSet>Unicode</CharacterSet>
-    <TargetFrameworkVersion>4.8</TargetFrameworkVersion>
+    <TargetFrameworkVersion>v4.8</TargetFrameworkVersion>
     <CLRSupport>true</CLRSupport>
     <IncludePath>$(MSBuildProjectDirectory)\..\WebRtcInterop;$(IncludePath)</IncludePath>
     <ManagedAssembly>true</ManagedAssembly>

--- a/WebRtcInterop/WebRtcInterop.Core.vcxproj
+++ b/WebRtcInterop/WebRtcInterop.Core.vcxproj
@@ -1,9 +1,17 @@
 <?xml version="1.0" encoding="utf-8"?>
 <Project DefaultTargets="Build" xmlns="http://schemas.microsoft.com/developer/msbuild/2003">
   <ItemGroup Label="ProjectConfigurations">
+    <ProjectConfiguration Include="Debug|ARM64">
+      <Configuration>Debug</Configuration>
+      <Platform>ARM64</Platform>
+    </ProjectConfiguration>
     <ProjectConfiguration Include="Debug|Win32">
       <Configuration>Debug</Configuration>
       <Platform>Win32</Platform>
+    </ProjectConfiguration>
+    <ProjectConfiguration Include="Release|ARM64">
+      <Configuration>Release</Configuration>
+      <Platform>ARM64</Platform>
     </ProjectConfiguration>
     <ProjectConfiguration Include="Release|Win32">
       <Configuration>Release</Configuration>
@@ -17,20 +25,12 @@
       <Configuration>Release</Configuration>
       <Platform>x64</Platform>
     </ProjectConfiguration>
-    <ProjectConfiguration Include="Debug|ARM64">
-      <Configuration>Debug</Configuration>
-      <Platform>ARM64</Platform>
-    </ProjectConfiguration>
-    <ProjectConfiguration Include="Release|ARM64">
-      <Configuration>Release</Configuration>
-      <Platform>ARM64</Platform>
-    </ProjectConfiguration>
   </ItemGroup>
   <PropertyGroup Label="Globals">
     <VCProjectVersion>17.0</VCProjectVersion>
     <ProjectGuid>{F259D9C3-8B07-4B62-A9B8-F0836178BC58}</ProjectGuid>
     <Keyword>NetCoreCProj</Keyword>
-    <TargetFramework>net10.0</TargetFramework>
+    <TargetFramework>net10.0-windows</TargetFramework>
     <CLRSupport>NetCore</CLRSupport>
   </PropertyGroup>
   <Import Project="$(VCTargetsPath)\Microsoft.Cpp.Default.props" />

--- a/WebRtcInterop/WebRtcInterop.Framework.vcxproj
+++ b/WebRtcInterop/WebRtcInterop.Framework.vcxproj
@@ -1,6 +1,14 @@
 <?xml version="1.0" encoding="utf-8"?>
 <Project DefaultTargets="Build" xmlns="http://schemas.microsoft.com/developer/msbuild/2003">
   <ItemGroup Label="ProjectConfigurations">
+    <ProjectConfiguration Include="Debug|ARM64">
+      <Configuration>Debug</Configuration>
+      <Platform>ARM64</Platform>
+    </ProjectConfiguration>
+    <ProjectConfiguration Include="Release|ARM64">
+      <Configuration>Release</Configuration>
+      <Platform>ARM64</Platform>
+    </ProjectConfiguration>
     <ProjectConfiguration Include="Debug|Win32">
       <Configuration>Debug</Configuration>
       <Platform>Win32</Platform>
@@ -17,19 +25,11 @@
       <Configuration>Release</Configuration>
       <Platform>x64</Platform>
     </ProjectConfiguration>
-    <ProjectConfiguration Include="Debug|ARM64">
-      <Configuration>Debug</Configuration>
-      <Platform>ARM64</Platform>
-    </ProjectConfiguration>
-    <ProjectConfiguration Include="Release|ARM64">
-      <Configuration>Release</Configuration>
-      <Platform>ARM64</Platform>
-    </ProjectConfiguration>
   </ItemGroup>
   <PropertyGroup Label="Globals">
     <VCProjectVersion>17.0</VCProjectVersion>
     <ProjectGuid>{26F36298-7F6A-4BD1-893B-2572BA180259}</ProjectGuid>
-    <Keyword>NetCoreCProj</Keyword>
+    <Keyword>ManagedCProj</Keyword>
     <TargetFrameworkVersion>v4.8</TargetFrameworkVersion>
     <CLRSupport>true</CLRSupport>
   </PropertyGroup>

--- a/WebRtcInterop/WebRtcInterop.Shared.vcxitems
+++ b/WebRtcInterop/WebRtcInterop.Shared.vcxitems
@@ -1,158 +1,159 @@
 ﻿<?xml version="1.0" encoding="utf-8"?>
 <Project xmlns="http://schemas.microsoft.com/developer/msbuild/2003">
-  <PropertyGroup Label="Globals">
-    <MSBuildAllProjects Condition="'$(MSBuildVersion)' == '' Or '$(MSBuildVersion)' &lt; '16.0'">$(MSBuildAllProjects);$(MSBuildThisFileFullPath)</MSBuildAllProjects>
-    <HasSharedItems>true</HasSharedItems>
-    <ItemsProjectGuid>{fac2e2bf-5a09-428f-a224-1ce7a160a2d1}</ItemsProjectGuid>
-  </PropertyGroup>
-  <Import Project="$(MSBuildThisFileDirectory)WebRtcInterop.BuildPaths.props" />
-  <PropertyGroup>
-    <WebRtcGnCommandPrefix>cd "$(WebRtcSrcRoot)"
+	<PropertyGroup Label="Globals">
+		<MSBuildAllProjects Condition="'$(MSBuildVersion)' == '' Or '$(MSBuildVersion)' &lt; '16.0'">$(MSBuildAllProjects);$(MSBuildThisFileFullPath)</MSBuildAllProjects>
+		<HasSharedItems>true</HasSharedItems>
+		<ItemsProjectGuid>{fac2e2bf-5a09-428f-a224-1ce7a160a2d1}</ItemsProjectGuid>
+	</PropertyGroup>
+	<Import Project="$(MSBuildThisFileDirectory)WebRtcInterop.BuildPaths.props"/>
+	<PropertyGroup>
+		<WebRtcGnCommandPrefix>cd "$(WebRtcSrcRoot)"
 echo Generating WebRtc Build Files
-cmd /c gn gen --ide=vs "$(WebRtcOutRoot)\$(Configuration)\$(Platform)" --filters=//:webrtc --args="</WebRtcGnCommandPrefix>
-    <WebRtcGnCommandSuffix>"
+cmd /c gn gen --ide=vs "$(WebRtcOutRoot)\$(Configuration)\$(Platform)" --filters=//:webrtc --args="
+		</WebRtcGnCommandPrefix>
+		<WebRtcGnCommandSuffix>"
 echo Compiling WebRtc Build Files
 ninja -C "$(WebRtcOutRoot)\$(Configuration)\$(Platform)"
-</WebRtcGnCommandSuffix>
-    <WebRtcGnCommonArgs>use_custom_libcxx=false libcxx_is_shared=true use_lld=false is_component_build=false clang_use_chrome_plugins=false rtc_include_tests=false rtc_build_tools=false rtc_build_examples=false rtc_enable_symbol_export=true rtc_enable_protobuf=false enable_libaom=false</WebRtcGnCommonArgs>
-  </PropertyGroup>
-  <PropertyGroup>
-    <IncludePath>$(ProjectDir);$(IncludePath)</IncludePath>
-    <CustomBuildBeforeTargets>PreBuildEvent</CustomBuildBeforeTargets>
-  </PropertyGroup>
-  <ItemDefinitionGroup>
-    <ClCompile>
-      <PrecompiledHeader>Use</PrecompiledHeader>
-      <PrecompiledHeaderFile>pch.h</PrecompiledHeaderFile>
-      <WarningLevel>Level3</WarningLevel>
-      <LanguageStandard>stdcpp20</LanguageStandard>
-      <LanguageStandard_C>stdc17</LanguageStandard_C>
-    </ClCompile>
-    <Link />
-  </ItemDefinitionGroup>
-  <ItemDefinitionGroup Condition="'$(Configuration)'=='Debug'">
-    <ClCompile>
-      <PreprocessorDefinitions>_DEBUG;%(PreprocessorDefinitions)</PreprocessorDefinitions>
-    </ClCompile>
-  </ItemDefinitionGroup>
-  <ItemDefinitionGroup Condition="'$(Configuration)'=='Release'">
-    <ClCompile>
-      <PreprocessorDefinitions>NDEBUG;%(PreprocessorDefinitions)</PreprocessorDefinitions>
-    </ClCompile>
-  </ItemDefinitionGroup>
-  <ItemDefinitionGroup Condition="'$(Platform)'=='Win32'">
-    <ClCompile>
-      <PreprocessorDefinitions>WIN32;%(PreprocessorDefinitions)</PreprocessorDefinitions>
-    </ClCompile>
-  </ItemDefinitionGroup>
-  <ItemDefinitionGroup Condition="'$(Platform)'=='ARM64'">
-    <ClCompile>
-      <PreprocessorDefinitions>ARM64;%(PreprocessorDefinitions)</PreprocessorDefinitions>
-    </ClCompile>
-  </ItemDefinitionGroup>
-  <!-- ARM64 webrtc.lib is built with iterator debugging disabled. -->
-  <ItemDefinitionGroup Condition="'$(Platform)'=='ARM64'">
-    <ClCompile>
-      <PreprocessorDefinitions>%(PreprocessorDefinitions);_ITERATOR_DEBUG_LEVEL=0</PreprocessorDefinitions>
-    </ClCompile>
-  </ItemDefinitionGroup>
-  <ItemDefinitionGroup>
-    <ClCompile>
-      <ExternalIncludePath>%(ExternalIncludePath);$(WebRtcSrcRoot);$(WebRtcSrcRoot)\system_wrappers;$(WebRtcSrcRoot)\third_party\abseil-cpp;$(WebRtcSrcRoot)\buildtools\third_party\libc++;$(WebRtcSrcRoot)\third_party\libyuv\include;$(WebRtcSrcRoot)\third_party\jsoncpp\source\include</ExternalIncludePath>
-      <ExternalWarningLevel>TurnOffAllWarnings</ExternalWarningLevel>
-      <AdditionalIncludeDirectories>%(AdditionalIncludeDirectories);$(MSBuildThisFileDirectory);$(WebRtcSrcRoot);$(WebRtcSrcRoot)\system_wrappers;$(WebRtcSrcRoot)\third_party\abseil-cpp;$(WebRtcSrcRoot)\buildtools\third_party\libc++;$(WebRtcSrcRoot)\third_party\libyuv\include;$(WebRtcSrcRoot)\third_party\jsoncpp\source\include</AdditionalIncludeDirectories>
-      <PreprocessorDefinitions>%(PreprocessorDefinitions);_HAS_EXCEPTIONS=0;__STD_C;_CRT_RAND_S;_CRT_SECURE_NO_DEPRECATE;_SCL_SECURE_NO_DEPRECATE;_ATL_NO_OPENGL;_WINDOWS;CERT_CHAIN_PARA_HAS_EXTRA_FIELDS;PSAPI_VERSION=2;WIN32;_SECURE_ATL;__WRL_NO_DEFAULT_LIB__;WINAPI_FAMILY=WINAPI_FAMILY_DESKTOP_APP;WIN10=_WIN32_WINNT_WIN10;WIN32_LEAN_AND_MEAN;NOMINMAX;_UNICODE;UNICODE;NTDDI_VERSION=NTDDI_WIN10_RS2;_WIN32_WINNT=0x0A00;WINVER=0x0A00;NVALGRIND;DYNAMIC_ANNOTATIONS_ENABLED=0;WEBRTC_ENABLE_PROTOBUF=0;WEBRTC_INCLUDE_INTERNAL_AUDIO_DEVICE;RTC_ENABLE_VP9;HAVE_SCTP;WEBRTC_LIBRARY_IMPL;WEBRTC_NON_STATIC_TRACE_EVENT_HANDLERS=0;WEBRTC_WIN;ABSL_ALLOCATOR_NOTHROW=1;HAVE_SCTP</PreprocessorDefinitions>
-    </ClCompile>
-    <Link>
-      <AdditionalLibraryDirectories>%(AdditionalLibraryDirectories);$(WebRtcOutRoot)\$(Configuration)\$(Platform)</AdditionalLibraryDirectories>
-      <AdditionalDependencies>webrtc.lib;Ws2_32.lib;iphlpapi.lib;Winmm.lib;$(CoreLibraryDependencies);%(AdditionalDependencies)</AdditionalDependencies>
-      <IgnoreSpecificDefaultLibraries>libcmtd;%(IgnoreSpecificDefaultLibraries)</IgnoreSpecificDefaultLibraries>
-    </Link>
-  </ItemDefinitionGroup>
-  <ItemDefinitionGroup Condition="'$(Configuration)|$(Platform)'=='Release|x64' and '$(WebRtcPrebuilt)' != '1'">
-    <CustomBuildStep>
-      <Command>$(WebRtcGnCommandPrefix)target_cpu="x64" is_debug=false enable_iterator_debugging=false $(WebRtcGnCommonArgs)$(WebRtcGnCommandSuffix)
-</Command>
-      <Message>Building Google WebRtc Library</Message>
-      <Outputs>$(WebRtcOutRoot)\$(Configuration)\$(Platform)\webrtc.lib</Outputs>
-    </CustomBuildStep>
-  </ItemDefinitionGroup>
-  <ItemDefinitionGroup Condition="'$(Configuration)|$(Platform)'=='Debug|x64' and '$(WebRtcPrebuilt)' != '1'">
-    <CustomBuildStep>
-      <Command>$(WebRtcGnCommandPrefix)target_cpu="x64" is_debug=true enable_iterator_debugging=true $(WebRtcGnCommonArgs)$(WebRtcGnCommandSuffix)
-</Command>
-      <Message>Building Google WebRtc Library</Message>
-      <Outputs>$(WebRtcOutRoot)\$(Configuration)\$(Platform)\webrtc.lib</Outputs>
-    </CustomBuildStep>
-  </ItemDefinitionGroup>
-  <ItemDefinitionGroup Condition="'$(Configuration)|$(Platform)'=='Release|ARM64' and '$(WebRtcPrebuilt)' != '1'">
-    <CustomBuildStep>
-      <Command>$(WebRtcGnCommandPrefix)target_cpu="arm64" is_debug=false enable_iterator_debugging=false rtc_enable_win_wgc=false $(WebRtcGnCommonArgs)$(WebRtcGnCommandSuffix)
-</Command>
-      <Message>Building Google WebRtc Library</Message>
-      <Outputs>$(WebRtcOutRoot)\$(Configuration)\$(Platform)\webrtc.lib</Outputs>
-    </CustomBuildStep>
-  </ItemDefinitionGroup>
-  <ItemDefinitionGroup Condition="'$(Configuration)|$(Platform)'=='Debug|ARM64' and '$(WebRtcPrebuilt)' != '1'">
-    <CustomBuildStep>
-      <Command>$(WebRtcGnCommandPrefix)target_cpu="arm64" is_debug=true enable_iterator_debugging=false rtc_enable_win_wgc=false $(WebRtcGnCommonArgs)$(WebRtcGnCommandSuffix)
-</Command>
-      <Message>Building Google WebRtc Library</Message>
-      <Outputs>$(WebRtcOutRoot)\$(Configuration)\$(Platform)\webrtc.lib</Outputs>
-    </CustomBuildStep>
-  </ItemDefinitionGroup>
-  <ItemDefinitionGroup Condition="'$(Configuration)|$(Platform)'=='Release|Win32' and '$(WebRtcPrebuilt)' != '1'">
-    <CustomBuildStep>
-      <Command>$(WebRtcGnCommandPrefix)target_cpu="x86" is_debug=false enable_iterator_debugging=false $(WebRtcGnCommonArgs)$(WebRtcGnCommandSuffix)
-</Command>
-      <Message>Building Google WebRtc Library</Message>
-      <Outputs>$(WebRtcOutRoot)\$(Configuration)\$(Platform)\webrtc.lib</Outputs>
-    </CustomBuildStep>
-  </ItemDefinitionGroup>
-  <ItemDefinitionGroup Condition="'$(Configuration)|$(Platform)'=='Debug|Win32' and '$(WebRtcPrebuilt)' != '1'">
-    <CustomBuildStep>
-      <Command>$(WebRtcGnCommandPrefix)target_cpu="x86" is_debug=true enable_iterator_debugging=true $(WebRtcGnCommonArgs)$(WebRtcGnCommandSuffix)
-</Command>
-      <Message>Building Google WebRtc Library</Message>
-      <Outputs>$(WebRtcOutRoot)\$(Configuration)\$(Platform)\webrtc.lib</Outputs>
-    </CustomBuildStep>
-  </ItemDefinitionGroup>
-  <ItemGroup>
-    <ProjectCapability Include="SourceItemsFromImports" />
-  </ItemGroup>
-  <ItemGroup>
-    <ProjectReference Include="$(MSBuildThisFileDirectory)..\WebRtcNet.Api\WebRtcNet.Api.csproj">
-      <Project>{98433217-c99b-4b08-a19b-3f97a1f1e633}</Project>
-    </ProjectReference>
-  </ItemGroup>
-  <ItemGroup>
-    <ClInclude Include="$(MSBuildThisFileDirectory)ManagedScopedRefPtr.h" />
-    <ClInclude Include="$(MSBuildThisFileDirectory)Marshaling\MarshalCollections.h" />
-    <ClInclude Include="$(MSBuildThisFileDirectory)Marshaling\MarshalDataChannel.h" />
-    <ClInclude Include="$(MSBuildThisFileDirectory)Marshaling\MarshalEnums.h" />
-    <ClInclude Include="$(MSBuildThisFileDirectory)Marshaling\MarshalIceTransport.h" />
-    <ClInclude Include="$(MSBuildThisFileDirectory)Marshaling\MarshalNullable.h" />
-    <ClInclude Include="$(MSBuildThisFileDirectory)Media\Marshaling\MarshalMedia.h" />
-    <ClInclude Include="$(MSBuildThisFileDirectory)Media\MediaStream.h" />
-    <ClInclude Include="$(MSBuildThisFileDirectory)Media\MediaStreamTrack.h" />
-    <ClInclude Include="$(MSBuildThisFileDirectory)NativeWrapper.h" />
-    <ClInclude Include="$(MSBuildThisFileDirectory)Observers\DataChannelObserver.h" />
-    <ClInclude Include="$(MSBuildThisFileDirectory)Resource.h" />
-    <ClInclude Include="$(MSBuildThisFileDirectory)RtcDataChannel.h" />
-    <ClInclude Include="$(MSBuildThisFileDirectory)RtcIceTransport.h" />
-  </ItemGroup>
-  <ItemGroup>
-    <ClCompile Include="$(MSBuildThisFileDirectory)Media\MediaStream.cpp" />
-    <ClCompile Include="$(MSBuildThisFileDirectory)Media\MediaStreamTrack.cpp" />
-    <ClCompile Include="$(MSBuildThisFileDirectory)Observers\DataChannelObserver.cpp" />
-    <ClCompile Include="$(MSBuildThisFileDirectory)RtcDataChannel.cpp" />
-    <ClCompile Include="$(MSBuildThisFileDirectory)RtcIceTransport.cpp" />
-  </ItemGroup>
-  <ItemGroup>
-    <ClCompile Include="$(MSBuildThisFileDirectory)AssemblyInfo.cpp" />
-    <ClCompile Include="$(MSBuildThisFileDirectory)pch.cpp">
-      <PrecompiledHeader>Create</PrecompiledHeader>
-    </ClCompile>
-    <ClInclude Include="$(MSBuildThisFileDirectory)pch.h" />
-  </ItemGroup>
+		</WebRtcGnCommandSuffix>
+		<WebRtcGnCommonArgs>use_custom_libcxx=false libcxx_is_shared=true use_lld=false is_component_build=false clang_use_chrome_plugins=false rtc_include_tests=false rtc_build_tools=false rtc_build_examples=false rtc_enable_symbol_export=true rtc_enable_protobuf=false enable_libaom=false</WebRtcGnCommonArgs>
+	</PropertyGroup>
+	<PropertyGroup>
+		<IncludePath>$(ProjectDir);$(IncludePath)</IncludePath>
+		<CustomBuildBeforeTargets>PreBuildEvent</CustomBuildBeforeTargets>
+	</PropertyGroup>
+	<ItemDefinitionGroup>
+		<ClCompile>
+			<PrecompiledHeader>Use</PrecompiledHeader>
+			<PrecompiledHeaderFile>pch.h</PrecompiledHeaderFile>
+			<WarningLevel>Level3</WarningLevel>
+			<LanguageStandard>stdcpp20</LanguageStandard>
+			<LanguageStandard_C>stdc17</LanguageStandard_C>
+		</ClCompile>
+		<Link/>
+	</ItemDefinitionGroup>
+	<ItemDefinitionGroup Condition="'$(Configuration)'=='Debug'">
+		<ClCompile>
+			<PreprocessorDefinitions>_DEBUG;%(PreprocessorDefinitions)</PreprocessorDefinitions>
+		</ClCompile>
+	</ItemDefinitionGroup>
+	<ItemDefinitionGroup Condition="'$(Configuration)'=='Release'">
+		<ClCompile>
+			<PreprocessorDefinitions>NDEBUG;%(PreprocessorDefinitions)</PreprocessorDefinitions>
+		</ClCompile>
+	</ItemDefinitionGroup>
+	<ItemDefinitionGroup Condition="'$(Platform)'=='x86'">
+		<ClCompile>
+			<PreprocessorDefinitions>WIN32;%(PreprocessorDefinitions)</PreprocessorDefinitions>
+		</ClCompile>
+	</ItemDefinitionGroup>
+	<ItemDefinitionGroup Condition="'$(Platform)'=='x64'">
+		<ClCompile>
+			<PreprocessorDefinitions>%(PreprocessorDefinitions)</PreprocessorDefinitions>
+		</ClCompile>
+	</ItemDefinitionGroup>
+	<!-- ARM64 webrtc.lib is built with iterator debugging disabled. -->
+	<ItemDefinitionGroup Condition="'$(Platform)'=='ARM64'">
+		<ClCompile>
+			<PreprocessorDefinitions>ARM64;%(PreprocessorDefinitions);_ITERATOR_DEBUG_LEVEL=0</PreprocessorDefinitions>
+		</ClCompile>
+	</ItemDefinitionGroup>
+	<ItemDefinitionGroup>
+		<ClCompile>
+			<ExternalIncludePath>%(ExternalIncludePath);$(WebRtcSrcRoot);$(WebRtcSrcRoot)\system_wrappers;$(WebRtcSrcRoot)\third_party\abseil-cpp;$(WebRtcSrcRoot)\buildtools\third_party\libc++;$(WebRtcSrcRoot)\third_party\libyuv\include;$(WebRtcSrcRoot)\third_party\jsoncpp\source\include</ExternalIncludePath>
+			<ExternalWarningLevel>TurnOffAllWarnings</ExternalWarningLevel>
+			<AdditionalIncludeDirectories>%(AdditionalIncludeDirectories);$(MSBuildThisFileDirectory);$(WebRtcSrcRoot);$(WebRtcSrcRoot)\system_wrappers;$(WebRtcSrcRoot)\third_party\abseil-cpp;$(WebRtcSrcRoot)\buildtools\third_party\libc++;$(WebRtcSrcRoot)\third_party\libyuv\include;$(WebRtcSrcRoot)\third_party\jsoncpp\source\include</AdditionalIncludeDirectories>
+			<PreprocessorDefinitions>%(PreprocessorDefinitions);_HAS_EXCEPTIONS=0;__STD_C;_CRT_RAND_S;_CRT_SECURE_NO_DEPRECATE;_SCL_SECURE_NO_DEPRECATE;_ATL_NO_OPENGL;_WINDOWS;CERT_CHAIN_PARA_HAS_EXTRA_FIELDS;PSAPI_VERSION=2;WIN32;_SECURE_ATL;__WRL_NO_DEFAULT_LIB__;WINAPI_FAMILY=WINAPI_FAMILY_DESKTOP_APP;WIN10=_WIN32_WINNT_WIN10;WIN32_LEAN_AND_MEAN;NOMINMAX;_UNICODE;UNICODE;NTDDI_VERSION=NTDDI_WIN10_RS2;_WIN32_WINNT=0x0A00;WINVER=0x0A00;NVALGRIND;DYNAMIC_ANNOTATIONS_ENABLED=0;WEBRTC_ENABLE_PROTOBUF=0;WEBRTC_INCLUDE_INTERNAL_AUDIO_DEVICE;RTC_ENABLE_VP9;HAVE_SCTP;WEBRTC_LIBRARY_IMPL;WEBRTC_NON_STATIC_TRACE_EVENT_HANDLERS=0;WEBRTC_WIN;ABSL_ALLOCATOR_NOTHROW=1;HAVE_SCTP</PreprocessorDefinitions>
+		</ClCompile>
+		<Link>
+			<AdditionalLibraryDirectories>%(AdditionalLibraryDirectories);$(WebRtcOutRoot)\$(Configuration)\$(Platform)</AdditionalLibraryDirectories>
+			<AdditionalDependencies>webrtc.lib;Ws2_32.lib;iphlpapi.lib;Winmm.lib;$(CoreLibraryDependencies);%(AdditionalDependencies)</AdditionalDependencies>
+			<IgnoreSpecificDefaultLibraries>libcmtd;%(IgnoreSpecificDefaultLibraries)</IgnoreSpecificDefaultLibraries>
+		</Link>
+	</ItemDefinitionGroup>
+	<ItemDefinitionGroup Condition="'$(Configuration)|$(Platform)'=='Release|x64' and '$(WebRtcPrebuilt)' != '1'">
+		<CustomBuildStep>
+			<Command>$(WebRtcGnCommandPrefix)target_cpu="x64" is_debug=false enable_iterator_debugging=false $(WebRtcGnCommonArgs)$(WebRtcGnCommandSuffix)
+			</Command>
+			<Message>Building Google WebRtc Library</Message>
+			<Outputs>$(WebRtcOutRoot)\$(Configuration)\$(Platform)\webrtc.lib</Outputs>
+		</CustomBuildStep>
+	</ItemDefinitionGroup>
+	<ItemDefinitionGroup Condition="'$(Configuration)|$(Platform)'=='Debug|x64' and '$(WebRtcPrebuilt)' != '1'">
+		<CustomBuildStep>
+			<Command>$(WebRtcGnCommandPrefix)target_cpu="x64" is_debug=true enable_iterator_debugging=true $(WebRtcGnCommonArgs)$(WebRtcGnCommandSuffix)
+			</Command>
+			<Message>Building Google WebRtc Library</Message>
+			<Outputs>$(WebRtcOutRoot)\$(Configuration)\$(Platform)\webrtc.lib</Outputs>
+		</CustomBuildStep>
+	</ItemDefinitionGroup>
+	<ItemDefinitionGroup Condition="'$(Configuration)|$(Platform)'=='Release|ARM64' and '$(WebRtcPrebuilt)' != '1'">
+		<CustomBuildStep>
+			<Command>$(WebRtcGnCommandPrefix)target_cpu="arm64" is_debug=false enable_iterator_debugging=false rtc_enable_win_wgc=false $(WebRtcGnCommonArgs)$(WebRtcGnCommandSuffix)
+			</Command>
+			<Message>Building Google WebRtc Library</Message>
+			<Outputs>$(WebRtcOutRoot)\$(Configuration)\$(Platform)\webrtc.lib</Outputs>
+		</CustomBuildStep>
+	</ItemDefinitionGroup>
+	<ItemDefinitionGroup Condition="'$(Configuration)|$(Platform)'=='Debug|ARM64' and '$(WebRtcPrebuilt)' != '1'">
+		<CustomBuildStep>
+			<Command>$(WebRtcGnCommandPrefix)target_cpu="arm64" is_debug=true enable_iterator_debugging=false rtc_enable_win_wgc=false $(WebRtcGnCommonArgs)$(WebRtcGnCommandSuffix)
+			</Command>
+			<Message>Building Google WebRtc Library</Message>
+			<Outputs>$(WebRtcOutRoot)\$(Configuration)\$(Platform)\webrtc.lib</Outputs>
+		</CustomBuildStep>
+	</ItemDefinitionGroup>
+	<ItemDefinitionGroup Condition="'$(Configuration)|$(Platform)'=='Release|x86' and '$(WebRtcPrebuilt)' != '1'">
+		<CustomBuildStep>
+			<Command>$(WebRtcGnCommandPrefix)target_cpu="x86" is_debug=false enable_iterator_debugging=false $(WebRtcGnCommonArgs)$(WebRtcGnCommandSuffix)
+			</Command>
+			<Message>Building Google WebRtc Library</Message>
+			<Outputs>$(WebRtcOutRoot)\$(Configuration)\$(Platform)\webrtc.lib</Outputs>
+		</CustomBuildStep>
+	</ItemDefinitionGroup>
+	<ItemDefinitionGroup Condition="'$(Configuration)|$(Platform)'=='Debug|x86' and '$(WebRtcPrebuilt)' != '1'">
+		<CustomBuildStep>
+			<Command>$(WebRtcGnCommandPrefix)target_cpu="x86" is_debug=true enable_iterator_debugging=true $(WebRtcGnCommonArgs)$(WebRtcGnCommandSuffix)
+			</Command>
+			<Message>Building Google WebRtc Library</Message>
+			<Outputs>$(WebRtcOutRoot)\$(Configuration)\$(Platform)\webrtc.lib</Outputs>
+		</CustomBuildStep>
+	</ItemDefinitionGroup>
+	<ItemGroup>
+		<ProjectCapability Include="SourceItemsFromImports"/>
+	</ItemGroup>
+	<ItemGroup>
+		<ProjectReference Include="$(MSBuildThisFileDirectory)..\WebRtcNet.Api\WebRtcNet.Api.csproj">
+			<Project>{98433217-c99b-4b08-a19b-3f97a1f1e633}</Project>
+		</ProjectReference>
+	</ItemGroup>
+	<ItemGroup>
+		<ClInclude Include="$(MSBuildThisFileDirectory)ManagedScopedRefPtr.h"/>
+		<ClInclude Include="$(MSBuildThisFileDirectory)Marshaling\MarshalCollections.h"/>
+		<ClInclude Include="$(MSBuildThisFileDirectory)Marshaling\MarshalDataChannel.h"/>
+		<ClInclude Include="$(MSBuildThisFileDirectory)Marshaling\MarshalEnums.h"/>
+		<ClInclude Include="$(MSBuildThisFileDirectory)Marshaling\MarshalIceTransport.h"/>
+		<ClInclude Include="$(MSBuildThisFileDirectory)Marshaling\MarshalNullable.h"/>
+		<ClInclude Include="$(MSBuildThisFileDirectory)Media\Marshaling\MarshalMedia.h"/>
+		<ClInclude Include="$(MSBuildThisFileDirectory)Media\MediaStream.h"/>
+		<ClInclude Include="$(MSBuildThisFileDirectory)Media\MediaStreamTrack.h"/>
+		<ClInclude Include="$(MSBuildThisFileDirectory)NativeWrapper.h"/>
+		<ClInclude Include="$(MSBuildThisFileDirectory)Observers\DataChannelObserver.h"/>
+		<ClInclude Include="$(MSBuildThisFileDirectory)Resource.h"/>
+		<ClInclude Include="$(MSBuildThisFileDirectory)RtcDataChannel.h"/>
+		<ClInclude Include="$(MSBuildThisFileDirectory)RtcIceTransport.h"/>
+	</ItemGroup>
+	<ItemGroup>
+		<ClCompile Include="$(MSBuildThisFileDirectory)Media\MediaStream.cpp"/>
+		<ClCompile Include="$(MSBuildThisFileDirectory)Media\MediaStreamTrack.cpp"/>
+		<ClCompile Include="$(MSBuildThisFileDirectory)Observers\DataChannelObserver.cpp"/>
+		<ClCompile Include="$(MSBuildThisFileDirectory)RtcDataChannel.cpp"/>
+		<ClCompile Include="$(MSBuildThisFileDirectory)RtcIceTransport.cpp"/>
+	</ItemGroup>
+	<ItemGroup>
+		<ClCompile Include="$(MSBuildThisFileDirectory)AssemblyInfo.cpp"/>
+		<ClCompile Include="$(MSBuildThisFileDirectory)pch.cpp">
+			<PrecompiledHeader>Create</PrecompiledHeader>
+		</ClCompile>
+		<ClInclude Include="$(MSBuildThisFileDirectory)pch.h"/>
+	</ItemGroup>
 </Project>

--- a/WebRtcInterop/WebRtcInterop.default.props
+++ b/WebRtcInterop/WebRtcInterop.default.props
@@ -1,16 +1,16 @@
 <?xml version="1.0" encoding="utf-8"?>
 <Project xmlns="http://schemas.microsoft.com/developer/msbuild/2003">
-  <PropertyGroup>
-    <RootNamespace>WebRtcInterop</RootNamespace>
-    <WindowsTargetPlatformVersion>10.0</WindowsTargetPlatformVersion>
-    <ConfigurationType>DynamicLibrary</ConfigurationType>
-    <PlatformToolset>v145</PlatformToolset>
-    <CharacterSet>Unicode</CharacterSet>
-  </PropertyGroup>
-  <PropertyGroup Condition="'$(Configuration)'=='Debug'" Label="Configuration">
-    <UseDebugLibraries>true</UseDebugLibraries>
-  </PropertyGroup>
-  <PropertyGroup Condition="'$(Configuration)'=='Release'" Label="Configuration">
-    <UseDebugLibraries>false</UseDebugLibraries>
-  </PropertyGroup>
+	<PropertyGroup>
+		<RootNamespace>WebRtcInterop</RootNamespace>
+		<WindowsTargetPlatformVersion>10.0</WindowsTargetPlatformVersion>
+		<ConfigurationType>DynamicLibrary</ConfigurationType>
+		<PlatformToolset>v145</PlatformToolset>
+		<CharacterSet>Unicode</CharacterSet>
+	</PropertyGroup>
+	<PropertyGroup Condition="'$(Configuration)'=='Debug'" Label="Configuration">
+		<UseDebugLibraries>true</UseDebugLibraries>
+	</PropertyGroup>
+	<PropertyGroup Condition="'$(Configuration)'=='Release'" Label="Configuration">
+		<UseDebugLibraries>false</UseDebugLibraries>
+	</PropertyGroup>
 </Project>

--- a/WebRtcNet.Api.UnitTests/WebRtcNet.Api.UnitTests.csproj
+++ b/WebRtcNet.Api.UnitTests/WebRtcNet.Api.UnitTests.csproj
@@ -1,20 +1,19 @@
 ﻿<Project Sdk="Microsoft.NET.Sdk">
-  <PropertyGroup>
-    <TargetFrameworks>net10.0;net48</TargetFrameworks>
-    <OutputType>Library</OutputType>
-    <Configurations>Debug;Release</Configurations>
-    <Platforms>AnyCPU;x64;x86;ARM64</Platforms>
-    <AssemblyTitle>WebRtcNet.UnitTests</AssemblyTitle>
-    <AssemblyDescription>Unit tests for the WebRtcNet assembly</AssemblyDescription>
-    <Guid>54bcf14f-4d80-4bfc-b51c-b67df6de2e0d</Guid>
-    <LangVersion>latest</LangVersion>
-  </PropertyGroup>
-  <ItemGroup>
-    <PackageReference Include="Microsoft.NET.Test.Sdk" Version="17.14.1" />
-    <PackageReference Include="NUnit" Version="4.6.1" />
-    <PackageReference Include="NUnit3TestAdapter" Version="4.6.0" />
-  </ItemGroup>
-  <ItemGroup>
-    <ProjectReference Include="..\WebRtcNet.Api\WebRtcNet.Api.csproj" />
-  </ItemGroup>
+	<PropertyGroup>
+		<TargetFrameworks>net10.0-windows;net48</TargetFrameworks>
+		<OutputType>Library</OutputType>
+		<Platforms>ARM64;x64;x86</Platforms>
+		<AssemblyTitle>WebRtcNet.UnitTests</AssemblyTitle>
+		<AssemblyDescription>Unit tests for the WebRtcNet assembly</AssemblyDescription>
+		<Guid>54bcf14f-4d80-4bfc-b51c-b67df6de2e0d</Guid>
+		<LangVersion>latest</LangVersion>
+		</PropertyGroup>
+	<ItemGroup>
+		<PackageReference Include="Microsoft.NET.Test.Sdk" Version="17.14.1" />
+		<PackageReference Include="NUnit" Version="4.6.1" />
+		<PackageReference Include="NUnit3TestAdapter" Version="4.6.0" />
+	</ItemGroup>
+	<ItemGroup>
+		<ProjectReference Include="..\WebRtcNet.Api\WebRtcNet.Api.csproj" />
+	</ItemGroup>
 </Project>

--- a/WebRtcNet.Api/WebRtcNet.Api.csproj
+++ b/WebRtcNet.Api/WebRtcNet.Api.csproj
@@ -1,14 +1,12 @@
 ﻿<Project Sdk="Microsoft.NET.Sdk">
 	<PropertyGroup>
-		<TargetFrameworks>net10.0;net48</TargetFrameworks>
+		<TargetFrameworks>net10.0-windows;net48</TargetFrameworks>
 		<OutputType>Library</OutputType>
-		<Configurations>Debug;Release</Configurations>
-		<Platforms>AnyCPU;x64;x86;ARM64</Platforms>
+		<Platforms>ARM64;x64;x86</Platforms>
 		<AssemblyTitle>WebRtcNet.Api</AssemblyTitle>
 		<AssemblyDescription>The public WebRtc interfaces and classes for the WebRtcNet library</AssemblyDescription>
 		<Guid>98433217-c99b-4b08-a19b-3f97a1f1e633</Guid>
 		<DocumentationFile>$(OutputPath)$(TargetFramework)\WebRtcNet.Api.XML</DocumentationFile>
-		<AutoGenerateBindingRedirects>true</AutoGenerateBindingRedirects>
 		<LangVersion>latest</LangVersion>
 		<RootNamespace>WebRtcNet</RootNamespace>
 	</PropertyGroup>

--- a/WebRtcNet.slnx
+++ b/WebRtcNet.slnx
@@ -26,9 +26,25 @@
     <Project Path="third-party/shared-items/googletest/googletest.vcxitems" Id="357b6b66-ab73-41cd-9271-1b4e5c41dde1" />
   </Folder>
   <Folder Name="/Examples/">
-    <Project Path="examples/BasicVideoChat/BasicVideoChat.csproj" Id="ce07d5b9-b81d-4834-a99b-6917ae0b5982" />
+    <Project Path="examples/BasicVideoChat/BasicVideoChat.csproj" Id="ce07d5b9-b81d-4834-a99b-6917ae0b5982">
+      <Platform Solution="*|ARM64" Project="ARM64" />
+      <Platform Solution="*|x64" Project="x64" />
+      <Platform Solution="*|x86" Project="x86" />
+    </Project>
   </Folder>
-  <Project Path="WebRtcNet.Api.UnitTests/WebRtcNet.Api.UnitTests.csproj" />
-  <Project Path="WebRtcNet.Api/WebRtcNet.Api.csproj" />
-  <Project Path="WebRtcNet/WebRtcNet.csproj" />
+  <Project Path="WebRtcNet.Api.UnitTests/WebRtcNet.Api.UnitTests.csproj">
+    <Platform Solution="*|ARM64" Project="ARM64" />
+    <Platform Solution="*|x64" Project="x64" />
+    <Platform Solution="*|x86" Project="x86" />
+  </Project>
+  <Project Path="WebRtcNet.Api/WebRtcNet.Api.csproj">
+    <Platform Solution="*|ARM64" Project="ARM64" />
+    <Platform Solution="*|x64" Project="x64" />
+    <Platform Solution="*|x86" Project="x86" />
+  </Project>
+  <Project Path="WebRtcNet/WebRtcNet.csproj">
+    <Platform Solution="*|ARM64" Project="ARM64" />
+    <Platform Solution="*|x64" Project="x64" />
+    <Platform Solution="*|x86" Project="x86" />
+  </Project>
 </Solution>

--- a/WebRtcNet/WebRtcNet.csproj
+++ b/WebRtcNet/WebRtcNet.csproj
@@ -1,25 +1,24 @@
 ﻿<Project Sdk="Microsoft.NET.Sdk">
-  <PropertyGroup>
-    <TargetFrameworks>net10.0;net48</TargetFrameworks>
-    <OutputType>Library</OutputType>
-    <Configurations>Debug;Release</Configurations>
-    <Platforms>x64;x86;ARM64</Platforms>
-    <AssemblyTitle>WebRtcNet</AssemblyTitle>
-    <AssemblyDescription>A WebRtc implementation for .Net</AssemblyDescription>
-    <Guid>3CA16CE5-8124-4D86-8E37-2171B15BE276</Guid>
-    <AutoGenerateBindingRedirects>true</AutoGenerateBindingRedirects>
-    <LangVersion>latest</LangVersion>
-  </PropertyGroup>
+	<PropertyGroup>
+		<TargetFrameworks>net10.0-windows;net48</TargetFrameworks>
+		<OutputType>Library</OutputType>
+		<Platforms>ARM64;x64;x86</Platforms>
+		<AssemblyTitle>WebRtcNet</AssemblyTitle>
+		<AssemblyDescription>A WebRtc implementation for .Net</AssemblyDescription>
+		<Guid>3CA16CE5-8124-4D86-8E37-2171B15BE276</Guid>
+		<AutoGenerateBindingRedirects>true</AutoGenerateBindingRedirects>
+		<LangVersion>latest</LangVersion>
+	</PropertyGroup>
 
-  <PropertyGroup>
-    <PackageLicenseFile>..\LICENSE</PackageLicenseFile>
-    <PackageRequireLicenseAcceptance>True</PackageRequireLicenseAcceptance>
-    <DocumentationFile>$(OutputPath)$(TargetFramework)\WebRtcNet.XML</DocumentationFile>
-  </PropertyGroup>
+	<PropertyGroup>
+		<PackageLicenseFile>..\LICENSE</PackageLicenseFile>
+		<PackageRequireLicenseAcceptance>True</PackageRequireLicenseAcceptance>
+		<DocumentationFile>$(OutputPath)$(TargetFramework)\WebRtcNet.XML</DocumentationFile>
+	</PropertyGroup>
 
-  <ItemGroup>
-    <ProjectReference Include="..\WebRtcInterop\WebRtcInterop.Framework.vcxproj" Condition=" '$(TargetFramework)' == 'net48' "/>
-    <ProjectReference Include="..\WebRtcInterop\WebRtcInterop.Core.vcxproj" Condition=" '$(TargetFramework)' == 'net10.0' "/>
-    <ProjectReference Include="..\WebRtcNet.Api\WebRtcNet.Api.csproj" />
-  </ItemGroup>
+	<ItemGroup>
+		<ProjectReference Include="..\WebRtcInterop\WebRtcInterop.Framework.vcxproj" Condition="'$(TargetFramework)' == 'net48'" ReferenceOutputAssembly="true" Private="true" PrivateAssets="none" />
+		<ProjectReference Include="..\WebRtcInterop\WebRtcInterop.Core.vcxproj" Condition="'$(TargetFramework)' == 'net10.0-windows'" ReferenceOutputAssembly="true" Private="true" PrivateAssets="none" />
+		<ProjectReference Include="..\WebRtcNet.Api\WebRtcNet.Api.csproj"/>
+	</ItemGroup>
 </Project>

--- a/examples/BasicVideoChat/MainWindow.xaml.cs
+++ b/examples/BasicVideoChat/MainWindow.xaml.cs
@@ -19,7 +19,7 @@ public partial class MainWindow : Window
 	private static readonly RtcConfiguration DefaultConfiguration = new(
 		new[] { new RtcIceServer("stun:stun.l.google.com:19302") });
 
-	private WebRtcInterop.RtcPeerConnection? _peerConnection;
+	private RtcPeerConnection? _peerConnection;
 	private TcpSignalingChannel? _signaling;
 	private MediaStream? _localStream;
 	private MediaStreamTrack? _audioTrack;
@@ -76,7 +76,7 @@ public partial class MainWindow : Window
 	{
 		SetStatus("Acquiring media...");
 
-		var mediaDevices = new WebRtcInterop.Media.MediaDevices();
+		var mediaDevices = CreateInteropInstance<MediaDevices>("WebRtcInterop.Media.MediaDevices");
 		_localStream = await mediaDevices.GetUserMedia(new MediaStreamConstraints(true, true));
 
 		_audioTrack = _localStream.GetAudioTracks().FirstOrDefault();
@@ -89,7 +89,7 @@ public partial class MainWindow : Window
 		// NOTE: Many WebRtcInterop methods currently throw NotImplementedException — this example
 		// will not run end-to-end until they are implemented.  SetLocalDescription and
 		// AddIceCandidate are the minimum required for a basic call flow.
-		_peerConnection = new WebRtcInterop.RtcPeerConnection(DefaultConfiguration);
+		_peerConnection = CreateInteropInstance<RtcPeerConnection>("WebRtcInterop.RtcPeerConnection", DefaultConfiguration);
 		_peerConnection.OnIceCandidate += OnIceCandidate;
 		_peerConnection.OnTrack += OnTrack;
 		_peerConnection.OnConnectionStateChange += OnConnectionStateChange;
@@ -223,4 +223,19 @@ public partial class MainWindow : Window
 
 	private void SetStatus(string message) =>
 		Dispatcher.Invoke(() => StatusText.Text = message);
+
+	private static T CreateInteropInstance<T>(string fullTypeName, params object[] args) where T : class
+	{
+		var type =
+			Type.GetType($"{fullTypeName}, WebRtcInterop.Core") ??
+			Type.GetType($"{fullTypeName}, WebRtcInterop.Framework") ??
+			Type.GetType($"{fullTypeName}, WebRtcInterop");
+		if (type == null)
+			throw new NotSupportedException($"{fullTypeName} is not available. Ensure WebRtcInterop is built for the active target framework.");
+
+		if (Activator.CreateInstance(type, args) is T instance)
+			return instance;
+
+		throw new InvalidOperationException($"{fullTypeName} does not implement {typeof(T).FullName}.");
+	}
 }


### PR DESCRIPTION
## Summary
- Align managed target frameworks and project platform declarations.
- Add explicit solution platform mappings to remove configuration mismatch warnings.
- Update interop project reference conditions and metadata consistency.
- Keep BasicVideoChat compile path aligned with the new project binding model.

Closes #41